### PR TITLE
fixed issues related to TLS verification.

### DIFF
--- a/node-client/src/config_types.ts
+++ b/node-client/src/config_types.ts
@@ -15,10 +15,13 @@ export function newClusters(a: any): Cluster[] {
 
 function clusterIterator(): u.ListIterator<any, Cluster> {
     return function (elt: any, i: number, list: u.List<any>): Cluster {
+
+        const skipTLSVerify = !!elt.cluster['insecure-skip-tls-verify'];
+
         if (!elt['name']) {
             throw new Error(`clusters${i}.name is missing`);
         }
-        if (!elt.cluster['certificate-authority-data'] && !elt.cluster['certificate-authority']) {
+        if (!skipTLSVerify && (!elt.cluster['certificate-authority-data'] && !elt.cluster['certificate-authority'])) {
             throw new Error(`clusters[${i}].cluster.[certificate-authority-data, certificate-authority] is missing`);
         }
         if (!elt.cluster['server']) {
@@ -29,7 +32,7 @@ function clusterIterator(): u.ListIterator<any, Cluster> {
             caData: elt.cluster['certificate-authority-data'],
             caFile: elt.cluster['certificate-authority'],
             server: elt.cluster['server'],
-            skipTLSVerify: elt.cluster['insecure-skip-tls-verify'] == 'true'
+            skipTLSVerify: skipTLSVerify
         };
     }
 }


### PR DESCRIPTION
I found two issues related to TLS verification.

Originally, the check relied on "falsy" conversions that were invalid.

`elt.cluster['insecure-skip-tls-verify'] == 'true'`

where `elt.cluster['insecure-skip-tls-verify']` was a boolean, and `'true'` was a string.

`true == 'true'` is false.

The other issue, is that it expected `certificate-authority-data` and `certificate-authority` even if `skipTLSVerify` was true.
