### PR TITLE
fix(auth): wrong case for auth-provider

### DIFF
--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -117,8 +117,8 @@ export class KubeConfig {
         opts.cert = this.bufferFromFileOrString(user.certFile, user.certData);
         opts.key = this.bufferFromFileOrString(user.keyFile, user.keyData);
         let token = null;
-        if (user['auth-provider'] && user['auth-provider']['config']) {
-            let config = user['auth-provider']['config'];
+        if (user.authProvider && user.authProvider.config) {
+            let config = user.authProvider.config;
             // This should probably be extracted as auth-provider specific plugins...
             token = 'Bearer ' + config['access-token'];
             let expiry = config['expiry'];


### PR DESCRIPTION
Hi, 
I receive a HTTP 403, every time I try to use the client from `k8s.Config.defaultClient()`

After some researches, I think the `applyToRequest` use a wrong case for `authProvider` based on https://github.com/kubernetes-client/javascript/blob/master/node-client/src/config_types.ts#L68