### PR TITLE
 Update use of js-yaml for compatibility with newer type defintions 

### DIFF
--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -165,12 +165,12 @@ export class KubeConfig {
 
     public loadFromString(config: string) {
         var obj = yaml.safeLoad(config);
-        if (obj.apiVersion != 'v1') {
-            throw new TypeError('unknown version: ' + obj.apiVersion);
+        if (obj['apiVersion'] != 'v1') {
+            throw new TypeError('unknown version: ' + obj['apiVersion']);
         }
-        this.clusters = newClusters(obj.clusters);
-        this.contexts = newContexts(obj.contexts);
-        this.users = newUsers(obj.users);
+        this.clusters = newClusters(obj['clusters']);
+        this.contexts = newContexts(obj['contexts']);
+        this.users = newUsers(obj['users']);
         this.currentContext = obj['current-context'];
     }
 }


### PR DESCRIPTION
A [recent change][0] changed the return type of `safeLoad` from `any` to `object`. Accessing any property on a value of type `object` generates a compiler error.

```
src/config.ts(168,17): error TS2339: Property 'apiVersion' does not exist on type 'object'.
```

[0]: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/ae9aff4a0c0ccdc224583f0f7f84d3a5b7bc3483