### PR TITLE
Remove unused index.ts file at root of package

### DIFF
--- a/node-client/index.ts
+++ b/node-client/index.ts
@@ -1,5 +1,0 @@
-export * from './src/config';
-export * from './src/api';
-export * from './src/attach';
-export * from './src/watch';
-export * from './src/exec';

--- a/node-client/package.json
+++ b/node-client/package.json
@@ -8,8 +8,7 @@
   },
   "files": [
     "dist/src/*.ts",
-    "dist/src/*.js",
-    "index.ts"
+    "dist/src/*.js"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/node-client/package.json
+++ b/node-client/package.json
@@ -7,8 +7,8 @@
     "url": "git+https://github.com/kubernetes-client/javascript.git"
   },
   "files": [
-    "dist/src/*.ts",
-    "dist/src/*.js"
+    "dist/*.ts",
+    "dist/*.js"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This causes compiler errors when trying to import the package in a typescript project

I describe this in better detail here: https://github.com/kubernetes-client/javascript/issues/23#issuecomment-377441951

Closes #23