### PR TITLE
fix token refresh for GKE on Windows

### DIFF
--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -137,7 +137,7 @@ export class KubeConfig {
                         // TODO: Cache to file?
                         const result = shelljs.exec(cmd, { silent: true });
                         if (result['code'] != 0) {
-                            throw new Error('Failed to refresh token: ' + result);
+                            throw new Error('Failed to refresh token: ' + result.stderr);
                         }
                         let resultObj = JSON.parse(result.stdout.toString());
 

--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -130,7 +130,7 @@ export class KubeConfig {
                 let expiration = Date.parse(expiry);
                 if (expiration < Date.now()) {
                     if (config['cmd-path']) {
-                        let cmd = config['cmd-path'];
+                        let cmd = '"' + config['cmd-path'] + '"';
                         if (config['cmd-args']) {
                             cmd = cmd + ' ' + config['cmd-args'];
                         }


### PR DESCRIPTION
A proper solution would be to pass command line arguments as an array.
Unfortunately, this is not currently possible with shelljs. See also
https://github.com/shelljs/shelljs/issues/143.

As a workaround, surround the command with quotes to at least fix
commands with spaces.

Closes #50.