### PR TITLE
fix: parse insecure-skip-tls-verify correctly

### DIFF
--- a/node-client/src/config_test.ts
+++ b/node-client/src/config_test.ts
@@ -60,6 +60,7 @@ describe("KubeConfig", () => {
             expect(cluster2.name).to.equal("cluster2");
             expect(cluster2.caData).to.equal("Q0FEQVRBMg==");
             expect(cluster2.server).to.equal("http://example2.com");
+            expect(cluster2.skipTLSVerify).to.equal(true);
 
             // check users
             expect(kc.users.length).to.equal(2);

--- a/node-client/src/config_types.ts
+++ b/node-client/src/config_types.ts
@@ -26,7 +26,7 @@ function clusterIterator(): u.ListIterator<any, Cluster> {
             caData: elt.cluster['certificate-authority-data'],
             caFile: elt.cluster['certificate-authority'],
             server: elt.cluster['server'],
-            skipTLSVerify: elt.cluster['insecure-skip-tls-verify'] == 'true'
+            skipTLSVerify: elt.cluster['insecure-skip-tls-verify'] === true
         };
     }
 }

--- a/node-client/testdata/kubeconfig.yaml
+++ b/node-client/testdata/kubeconfig.yaml
@@ -7,6 +7,7 @@ clusters:
 - cluster:
     certificate-authority-data: Q0FEQVRBMg==
     server: http://example2.com
+    insecure-skip-tls-verify: true
   name: cluster2
 
 contexts:


### PR DESCRIPTION
A simple fix and test. The YAML parser will return the value as a boolean, so the comparison was incorrect.