### PR TITLE
node-client/src: change license from Unlicense to Apache-2.0

### DIFF
--- a/node-client/src/package.json
+++ b/node-client/src/package.json
@@ -10,8 +10,8 @@
         "build": "tsc",
         "test": "npm run build && node client.js"
     },
-    "author": "Swagger Codegen Contributors",
-    "license": "Unlicense",
+    "author": "Kubernetes Authors",
+    "license": "Apache-2.0",
     "dependencies": {
         "bluebird": "^3.3.5",
         "request": "^2.72.0"


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/223 and https://github.com/kubernetes/steering/issues/57:

> In the kubernetes-client javascript repo, a package.json file was added stating that the kubernetes-client-typescript package is under the Unlicense. Can this be corrected to Apache-2.0?