### PR TITLE
Fix node deprecation warning on Buffer constructor

### DIFF
--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -102,7 +102,7 @@ export class KubeConfig {
             return fs.readFileSync(file);
         }
         if (data) {
-            return new Buffer(base64.decode(data), 'utf-8');
+            return Buffer.from(base64.decode(data), 'utf-8');
         }
         return null;
     }

--- a/node-client/src/web-socket-handler.ts
+++ b/node-client/src/web-socket-handler.ts
@@ -89,7 +89,7 @@ export class WebSocketHandler {
 
     public static handleStandardInput(conn: ws.connection, stdin: stream.Readable | any) {
         stdin.on('data', (data) => {
-            let buff = new Buffer(data.length + 1);
+            let buff = Buffer.from(data.length + 1);
             buff.writeInt8(0, 0);
             if (data instanceof Buffer) {
                 data.copy(buff, 1);


### PR DESCRIPTION
Node 10 currently gives this deprecation warning

> (node:12492) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

So this pull request replaces all calls to Buffer::new by Buffer.from