### PR TITLE
fix(websockethandler): fix buffer init in handleStandardInput

### DIFF
--- a/node-client/src/web-socket-handler.ts
+++ b/node-client/src/web-socket-handler.ts
@@ -43,7 +43,7 @@ export class WebSocketHandler {
 
     public static handleStandardInput(conn: ws.connection, stdin: stream.Readable | any) {
         stdin.on('data', (data) => {
-            const buff = Buffer.from(data.length + 1);;
+            const buff = Buffer.from(data, data.length + 1);
             buff.writeInt8(0, 0);
             if (data instanceof Buffer) {
                 data.copy(buff, 1);


### PR DESCRIPTION
With this fix you can use a local readable stream as stdin on remote pod. 