### PR TITLE
fix `we need a path` error

### DIFF
--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -228,7 +228,7 @@ export class KubeConfig {
                         // Format in file is {<query>}, so slice it out and add '$'
                         pathKey = '$' + pathKey.slice(1, -1);
 
-                        config['access-token'] = jsonpath.query(resultObj, path);
+                        config['access-token'] = jsonpath.query(resultObj, pathKey);
                         token = 'Bearer ' + config['access-token'];
                     } else {
                         throw new Error('Token is expired!');


### PR DESCRIPTION
Commit 4ef92544 (Add tslint validation.) renames path to pathKey, but misses
one usage of the variable. This leads to the following error:

```
AssertionError [ERR_ASSERTION]: we need a path
    at JSONPath.query (...\node_modules\jsonpath\lib\index.js:92:10)
    at KubeConfig.applyAuthorizationHeader (...\node_modules\@kubernetes\client-node\dist\config.js:174:59)
```