### PR TITLE
Feature/api config helpers

### DIFF
--- a/node-client/package-lock.json
+++ b/node-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubernetes/client-node",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Re: #97 
I switched `ApiType` to a union type of a couple of Apis. However, this is probably not all of apis people use. Should we grok through and all of the Apis there or I can just revert it to what you had before?