### PR TITLE
LoadFromCluster, added option to prefix the configuration file path

### DIFF
--- a/node-client/src/config.ts
+++ b/node-client/src/config.ts
@@ -149,7 +149,7 @@ export class KubeConfig {
         ];
     }
 
-    public loadFromCluster() {
+    public loadFromCluster(pathPrefix: string = '') {
         const host = process.env.KUBERNETES_SERVICE_HOST;
         const port = process.env.KUBERNETES_SERVICE_PORT;
         const clusterName = 'inCluster';
@@ -164,7 +164,7 @@ export class KubeConfig {
         this.clusters = [
             {
                 name: clusterName,
-                caFile: Config.SERVICEACCOUNT_CA_PATH,
+                caFile: pathPrefix + Config.SERVICEACCOUNT_CA_PATH,
                 caData: null,
                 server: `${scheme}://${host}:${port}`,
                 skipTLSVerify: false,
@@ -173,7 +173,7 @@ export class KubeConfig {
         this.users = [
             {
                 name: userName,
-                token: fs.readFileSync(Config.SERVICEACCOUNT_TOKEN_PATH).toString(),
+                token: fs.readFileSync(pathPrefix + Config.SERVICEACCOUNT_TOKEN_PATH).toString(),
                 // empty defaults, fields are required...
                 certData: null,
                 certFile: null,


### PR DESCRIPTION
I'm trying to use this module with [telepresence](https://www.telepresence.io/), which will mount all volumes in a temporary subdirectory, so the Kubernetes Cluster configuration is not in its default path.
telepresenceio/telepresence#353

Since I want to be able to use this library with my telepresence setup, I've added the option to specify a prefix to the default path of the certs and tokens.

I'm aware, that this is an edge case, and the project would be better served if you could specify the whole path as the [`SERVICEACCOUNT_ROOT`](https://github.com/kubernetes-client/javascript/blob/master/node-client/src/config.ts#L318) in the config-class, but since that is deprecated, I think this is a sufficient midterm solution and my configuration could be replaced by a more robust solution when the classes get refactored.