### PR TITLE
Fix buffer trim while sending websocket messages

### DIFF
--- a/node-client/src/web-socket-handler.ts
+++ b/node-client/src/web-socket-handler.ts
@@ -43,7 +43,7 @@ export class WebSocketHandler {
 
     public static handleStandardInput(conn: ws.connection, stdin: stream.Readable | any) {
         stdin.on('data', (data) => {
-            const buff = Buffer.from(data, data.length + 1);
+            const buff = Buffer.alloc(data.length + 1);
             buff.writeInt8(0, 0);
             if (data instanceof Buffer) {
                 data.copy(buff, 1);


### PR DESCRIPTION
`Buffer.from` creates a new buffer of the same length of initial buffer or data. The data send over websocket needs to append one byte to identify message type (stdout/stdin/sterr).
This merge request creates the buffer with length = 1+ data length and copies over the data/