### PR TITLE
Add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean": "rm -Rf node_modules/ dist/",
     "build": "tsc",
     "watch": "tsc --watch",
-    "test": "nyc mocha"
+    "test": "nyc mocha",
+    "prepare": "npm run build"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
In trying to test out #141 I discovered we were missing the built files. 

Running `build` during the [prepare](https://docs.npmjs.com/misc/scripts) part of the install process these will be created during the install.  

cc/ @edvald 