### PR TITLE
watch method crash on unexpected objects

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -60,10 +60,10 @@ export class Watch {
             } else {
                 obj = JSON.parse(data) as WatchUpdate;
             }
-            if (obj.type && obj.object) {
+            if (typeof obj === 'object' && obj.object) {
                 callback(obj.type, obj.object);
             } else {
-                throw new Error(`unexpected object: ${JSON.stringify(obj)}`);
+                throw new Error(`unexpected ${typeof obj}: ${JSON.stringify(obj)}`);
             }
         });
 


### PR DESCRIPTION
The watch method should not crash if the k8s's reply object contains no `type` or `object`. Instead we check if the reply is an actual object and callback even if the `type` is `undefined`

Should fix (at least partially)
#146