### PR TITLE
Fixed ConfigMap patch header issue in Api lib

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -46439,7 +46439,7 @@ export class Core_v1Api {
             .replace('{' + 'name' + '}', String(name))
             .replace('{' + 'namespace' + '}', String(namespace));
         let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders, { 'Content-Type': 'application/merge-patch+json' });
         let formParams: any = {};
 
 


### PR DESCRIPTION
I found a issue with ConfigMap update in Api library.

If you do patch update on ConfigMap then the request will crash.

Reason: missing patch header

Reproduce:
```ts
this.apiService
    .patchNamespacedConfigMap(
        'configmap-name', 
        'default',
        { data: {  'key1': 'value 1',  'key2': 'value 2' } }
    );
```