### PR TITLE
Upgrade client badge to gold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Javascript Kubernetes Client information
 
 [![Build Status](https://travis-ci.org/kubernetes-client/javascript.svg?branch=master)](https://travis-ci.org/kubernetes-client/javascript)
-[![Client Capabilities](https://img.shields.io/badge/Kubernetes%20client-Silver-blue.svg?style=flat&colorB=C0C0C0&colorA=306CE8)](http://bit.ly/kubernetes-client-capabilities-badge)
+[![Client Capabilities](https://img.shields.io/badge/Kubernetes%20client-Gold-blue.svg?style=flat&colorB=FFD700&colorA=306CE8)](http://bit.ly/kubernetes-client-capabilities-badge)
 [![Client Support Level](https://img.shields.io/badge/kubernetes%20client-beta-green.svg?style=flat&colorA=306CE8)](http://bit.ly/kubernetes-client-support-badge)
 
 


### PR DESCRIPTION
I think this library qualifies as gold support under [csi-new-client-library-procedure](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)

We now support the following 

* Support watch calls
* Support exec, attach, port-forward calls (these are not normally supported out of the box from swagger-codegen)
* Proto encoding
* Generated examples


Not 100% sure about fully generated examples but we do have pretty good example code.

What do you think?