### PR TITLE
Support insecure-skip-tls-verify as config option for port-forward

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -253,6 +253,10 @@ export class KubeConfig {
         if (!user) {
             return;
         }
+
+        if (cluster != null && cluster.skipTLSVerify) {
+            opts.rejectUnauthorized = false;
+        }
         const ca = cluster != null ? bufferFromFileOrString(cluster.caFile, cluster.caData) : null;
         if (ca) {
             opts.ca = ca;

--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -105,7 +105,7 @@ export class WebSocketHandler implements WebSocketInterface {
         const uri = `${proto}://${target}${path}`;
 
         const opts: WebSocket.ClientOptions = {};
-        // TODO: This doesn't set insecureSSL if skipTLSVerify is set...
+
         this.config.applytoHTTPSOptions(opts);
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Propagate the `insecure-skip-tls-verify`  down to the `http` request library. 