### PR TITLE
Support commands with arguments in Exec

### DIFF
--- a/src/exec.ts
+++ b/src/exec.ts
@@ -17,12 +17,11 @@ export class Exec {
         }
     }
 
-    // TODO: make command an array and support multiple args
     /**
      * @param {string}  namespace - The namespace of the pod to exec the command inside.
      * @param {string} podName - The name of the pod to exec the command inside.
      * @param {string} containerName - The name of the container in the pod to exec the command inside.
-     * @param {string} command - The command to execute.
+     * @param {(string|string[])} command - The command or command and arguments to execute.
      * @param {stream.Writable} stdout - The stream to write stdout data from the command.
      * @param {stream.Writable} stderr - The stream to write stderr data from the command.
      * @param {stream.Readable} stdin - The strream to write stdin data into the command.
@@ -31,7 +30,7 @@ export class Exec {
      *       A callback to received the status (e.g. exit code) from the command, optional.
      * @return {string} This is the result
      */
-    public async exec(namespace: string, podName: string, containerName: string, command: string,
+    public async exec(namespace: string, podName: string, containerName: string, command: string | string[],
                       stdout: stream.Writable | null, stderr: stream.Writable | null, stdin: stream.Readable | null,
                       tty: boolean,
                       statusCallback?: (status: V1Status) => void): Promise<WebSocket> {

--- a/src/exec_test.ts
+++ b/src/exec_test.ts
@@ -22,6 +22,7 @@ describe('Exec', () => {
             const pod = 'somepod';
             const container = 'container';
             const cmd = 'command';
+            const cmdArray = ['command', 'arg1', 'arg2'];
             const path = `/api/v1/namespaces/${namespace}/pods/${pod}/exec`;
 
             await exec.exec(
@@ -48,6 +49,12 @@ describe('Exec', () => {
                 namespace, pod, container, cmd, null, errStream, isStream, true);
             args = `stdout=false&stderr=true&stdin=true&tty=true&command=${cmd}&container=${container}`;
             verify(fakeWebSocket.connect(`${path}?${args}`, null,  anyFunction())).called();
+
+            await exec.exec(
+                namespace, pod, container, cmdArray, null, errStream, isStream, true);
+            // tslint:disable-next-line:max-line-length
+            args = `stdout=false&stderr=true&stdin=true&tty=true&command=${cmdArray[0]}&command=${cmdArray[1]}&command=${cmdArray[2]}&container=${container}`;
+            verify(fakeWebSocket.connect(`${path}?${args}`, null, anyFunction())).called();
         });
 
         it('should correctly attach to streams', async () => {


### PR DESCRIPTION
PR for [issue 196](https://github.com/kubernetes-client/javascript/issues/196).

Since `exec` uses [`querystring.stringify`](https://nodejs.org/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options), which can serialize arrays as expected by the API, it already supports the requested functionality. This PR updates the typings and adds a test to reflect that.