### PR TITLE
move @types/ws to a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@types/node": "^10.12.0",
     "@types/request": "^2.47.1",
+    "@types/ws": "^6.0.1",
     "base-64": "^0.1.0",
     "bluebird": "^3.5.2",
     "byline": "^5.0.0",
@@ -70,7 +71,6 @@
     "@types/mocha": "^5.2.5",
     "@types/mock-fs": "^3.6.30",
     "@types/underscore": "^1.8.9",
-    "@types/ws": "^6.0.1",
     "chai": "^4.2.0",
     "jasmine": "^3.3.0",
     "mocha": "^5.2.0",


### PR DESCRIPTION
I believe this will fix a warning I'm getting:
node_modules/@kubernetes/client-node/dist/exec.d.ts:2:23 - error TS2688: Cannot find type definition file for 'ws'.

2 /// <reference types="ws" />