### PR TITLE
Move appropriate @types back to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubernetes/client-node",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -144,18 +144,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@types/base-64": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-0.1.2.tgz",
-      "integrity": "sha1-Y6wxgwLNq7XwToripW5U1IMhB+I=",
-      "dev": true
-    },
-    "@types/bluebird": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
-      "integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg==",
-      "dev": true
-    },
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
@@ -170,17 +158,7 @@
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-      "dev": true
-    },
-    "@types/execa": {
-      "version": "0.9.0",
-      "resolved": "http://registry.npmjs.org/@types/execa/-/execa-0.9.0.tgz",
-      "integrity": "sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/form-data": {
       "version": "2.2.1",
@@ -193,8 +171,7 @@
     "@types/js-yaml": {
       "version": "3.11.2",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.2.tgz",
-      "integrity": "sha512-JRDtMPEqXrzfuYAdqbxLot1GvAr/QvicIZAnOAigZaj8xVMhuSJTg/xsv9E1TvyL+wujYhRLx9ZsQ0oFOSmwyA==",
-      "dev": true
+      "integrity": "sha512-JRDtMPEqXrzfuYAdqbxLot1GvAr/QvicIZAnOAigZaj8xVMhuSJTg/xsv9E1TvyL+wujYhRLx9ZsQ0oFOSmwyA=="
     },
     "@types/mocha": {
       "version": "5.2.5",
@@ -235,14 +212,12 @@
     "@types/underscore": {
       "version": "1.8.9",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.9.tgz",
-      "integrity": "sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q==",
-      "dev": true
+      "integrity": "sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q=="
     },
     "@types/ws": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
       "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
-      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/node": "*"
@@ -375,11 +350,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -387,11 +357,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,11 @@
   "author": "Kubernetes Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/js-yaml": "^3.11.2",
     "@types/node": "^10.12.0",
     "@types/request": "^2.47.1",
+    "@types/underscore": "^1.8.9",
+    "@types/ws": "^6.0.1",
     "byline": "^5.0.0",
     "isomorphic-ws": "^4.0.1",
     "js-yaml": "^3.12.0",
@@ -61,11 +64,8 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",
-    "@types/js-yaml": "^3.11.2",
     "@types/mocha": "^5.2.5",
     "@types/mock-fs": "^3.6.30",
-    "@types/underscore": "^1.8.9",
-    "@types/ws": "^6.0.1",
     "chai": "^4.2.0",
     "jasmine": "^3.3.0",
     "mocha": "^5.2.0",


### PR DESCRIPTION
The types seem to have drifted back into the devDependencies from when I moved them over originally in https://github.com/kubernetes-client/javascript/pull/39
Reasoning: https://github.com/Microsoft/types-publisher/issues/81#issuecomment-234051338
I'm happy to rebase after related pull requests go through. 

Related:
https://github.com/kubernetes-client/javascript/issues/156
https://github.com/kubernetes-client/javascript/pull/160
https://github.com/kubernetes-client/javascript/pull/200
https://github.com/kubernetes-client/javascript/pull/201