### PR TITLE
add version check to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ node_js:
   - "8"
   - "10"
 
+before_install:
+  # Pre check to check that version matches package-lock.json
+  # needs to happen before npm install
+  - node version-check.js
+
 install:
   - 'npm install'
 script:

--- a/version-check.js
+++ b/version-check.js
@@ -1,0 +1,9 @@
+// This script is supposed to be run in travis to check package version matches
+// because of this it is designed to be run on a "clean" git checkout 
+// this will fail if run after npm install (since npm install updates package-lock)
+const packageVersion = require('./package.json').version 
+const lockVersion = require('./package-lock.json').version
+if (packageVersion != lockVersion) {
+    console.log(`version in package.json (${packageVersion}) does not match package-lock.json (${lockVersion})`);
+    process.exit(1);
+}


### PR DESCRIPTION
Adds a version check to CI this is so we always ensure the package-lock matches the package version before merging. (its happened a few times)