### PR TITLE
Assign value to exec attribute to fix exec auth issue

### DIFF
--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -61,6 +61,7 @@ function userIterator(): u.ListIterator<any, User> {
             authProvider: elt.user ? elt.user['auth-provider'] : null,
             certData: elt.user ? elt.user['client-certificate-data'] : null,
             certFile: elt.user ? elt.user['client-certificate'] : null,
+            exec: elt.user ? elt.user.exec : null,
             keyData: elt.user ? elt.user['client-key-data'] : null,
             keyFile: elt.user ? elt.user['client-key'] : null,
             name: elt.name,


### PR DESCRIPTION
As mentioned in #216, the exec attribute value was missing from the object when trying this library from master branch. I tested this change locally with an EKS cluster.