### PR TITLE
Fixed condition to check expired token for exec auth

### DIFF
--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -29,7 +29,7 @@ export class ExecAuth implements Authenticator {
         const cachedToken = this.tokenCache[user.name];
         if (cachedToken) {
             const date = Date.parse(cachedToken.status.expirationTimestamp);
-            if (date < Date.now()) {
+            if (date > Date.now()) {
                 return `Bearer ${cachedToken.status.token}`;
             }
             this.tokenCache[user.name] = null;


### PR DESCRIPTION
Fixes https://github.com/kubernetes-client/javascript/issues/228

It also fixes the issue where if the token is valid it was regenerating every time.