### PR TITLE
fixed bug on windows running cmd

### DIFF
--- a/src/cloud_auth.ts
+++ b/src/cloud_auth.ts
@@ -61,7 +61,7 @@ export class CloudAuth implements Authenticator {
         try {
             let cmd = config['cmd-path'];
             if (args) {
-                cmd = `${cmd} ${args}`;
+                cmd = `"${cmd}" ${args}`;
             }
             result = shelljs.exec(cmd, { silent: true });
             if (result.code !== 0) {


### PR DESCRIPTION
Hey I got this error on windows:

`Error: Failed to refresh token: '%localappdata%\Google\Cloud' is not recognized as an internal or external command`

Where the real path is actually:
"%localappdata\Google\Cloud SDK\cloud_env.bat"

but since it had space in the path, it didn't parse it correctly.
So I wrapped the path in quotes and it fixed it.

I checked it only on windows and it works great now.
I recommend checking it still works the same on other platforms.