### PR TITLE
Specify swagger-codegen version to pull in optional header override

### DIFF
--- a/settings
+++ b/settings
@@ -23,3 +23,6 @@ export CLIENT_VERSION="0.8-SNAPSHOT"
 
 # Name of the release package
 export PACKAGE_NAME="@kubernetes/node-client"
+
+# Swagger Codegen version: use last v2.
+export SWAGGER_CODEGEN_COMMIT="v2.4.5"


### PR DESCRIPTION
v2.4.2 includes the change to (optionally) override/set headers on every call.
See https://github.com/kubernetes-client/javascript/issues/19 for discussion.

Bump the swagger-codegen version all the way to v2.4.5 to pull in the fixes
after v2.4.2.