### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ts,js}]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ cd javascript
 
 ## Formatting
 
-Run `npm run format` or install an editor plugin like https://github.com/prettier/prettier-vscode.
+Run `npm run format` or install an editor plugin like https://github.com/prettier/prettier-vscode and https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
 
 ## Linting
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,32 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
-        "target": "es6",
-        "moduleResolution": "node",
-        "removeComments": false,
-        "sourceMap": true,
-        "noLib": false,
-        "declaration": true,
-        "outDir": "dist",
-        "rootDir": "src",
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": true,
-        "importHelpers": true
-        // enable this when it works with tslint, or we switch to prettier
-        // "declarationMap": true
-    },
-    "exclude": [
-        "node_modules",
-        "src/*_test.ts",
-        "dist"
-    ],
-    "include": [
-        "*.ts",
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitAny": false,
+    "suppressImplicitAnyIndexErrors": true,
+    "target": "es6",
+    "moduleResolution": "node",
+    "removeComments": false,
+    "sourceMap": true,
+    "noLib": false,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true
+    // enable this when it works with tslint, or we switch to prettier
+    // "declarationMap": true
+  },
+  "exclude": [
+    "node_modules",
+    "src/*_test.ts",
+    "dist"
+  ],
+  "include": [
+    "*.ts",
+    "src/**/*"
+  ]
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,20 +1,20 @@
 {
-    "extends": "tslint:recommended",
-    "defaultSeverity": "error",
-    "linterOptions": {
-        "exclude": [
-            "src/api.ts",
-            "dist",
-            "node_modules"
-         ]
-    },
-    "jsRules": {},
-    "rules": {
-        "quotemark": [true, "single", "avoid-escape", "avoid-template"],
-        "interface-name": [true, "never-prefix"],
-        "object-literal-sort-keys": false,
-        "object-literal-key-quotes": [true, "as-needed"],
-        "max-classes-per-file": false
-    },
-    "rulesDirectory": []
+  "extends": "tslint:recommended",
+  "defaultSeverity": "error",
+  "linterOptions": {
+    "exclude": [
+      "src/api.ts",
+      "dist",
+      "node_modules"
+    ]
+  },
+  "jsRules": {},
+  "rules": {
+    "quotemark": [true, "single", "avoid-escape", "avoid-template"],
+    "interface-name": [true, "never-prefix"],
+    "object-literal-sort-keys": false,
+    "object-literal-key-quotes": [true, "as-needed"],
+    "max-classes-per-file": false
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
We seem to have some issues with files that aren't typescript or JS files around formatting and newlines.

This adds [.editorconfig](https://editorconfig.org/) which allows us to configure these settings there are plugins for most [IDE's](https://editorconfig.org/#download) including [vim](https://github.com/editorconfig/editorconfig-vim#readme) and [vscode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig). 

This comes from a long discussion https://github.com/kubernetes-client/javascript/issues/203#issuecomment-460357987 

/assign @brendandburns 