### PR TITLE
Fix request import in log.ts

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,4 +1,4 @@
-import { default as request } from 'request';
+import request = require('request');
 import { Writable } from 'stream';
 
 import { KubeConfig } from './config';


### PR DESCRIPTION
Use the TypeScript CommonJS-style import:

  https://www.typescriptlang.org/docs/handbook/modules.html

because it looks like the request types use the CommonJS-style export:

  https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/request/index.d.ts#L397

CC https://github.com/kubernetes-client/javascript/issues/274