### PR TITLE
Disable `allowSyntheticDefaultImports` and `esModuleInterop`

### DIFF
--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -3,7 +3,7 @@ import * as https from 'https';
 import { dirname, join } from 'path';
 
 import { expect } from 'chai';
-import mockfs from 'mock-fs';
+import mockfs = require('mock-fs');
 import * as requestlib from 'request';
 import * as path from 'path';
 

--- a/src/integration_test.ts
+++ b/src/integration_test.ts
@@ -1,6 +1,6 @@
 import { expect, use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import nock from 'nock';
+import chaiAsPromised = require('chai-as-promised');
+import nock = require('nock');
 
 import { CoreV1Api } from './api';
 import { KubeConfig } from './config';

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,4 +1,4 @@
-import JSONStream from 'json-stream';
+import JSONStream = require('json-stream');
 import request = require('request');
 import { KubeConfig } from './config';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,6 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true


### PR DESCRIPTION
And fixes to the code that breaks from setting the above to false.

See https://github.com/kubernetes-client/javascript/issues/279