### PR TITLE
feat: add support for exec client cert authentication

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,24 +1,30 @@
 import { User } from './config_types';
 
-interface CredentialsBase {
+interface CredentialBase {
     expirationTimestamp?: string;
 }
 
-export interface TokenCredentials extends CredentialsBase {
-    type: 'token';
+export interface TokenCredential extends CredentialBase {
     token: string;
 }
 
-export interface ClientCertCredentials extends CredentialsBase {
-    type: 'client-cert';
+export interface ClientCertCredential extends CredentialBase {
     clientCertificateData: string;
     clientKeyData: string;
 }
 
-export type Credentials = TokenCredentials | ClientCertCredentials;
+export type Credential = TokenCredential | ClientCertCredential;
+
+export function isTokenCredential(c: Credential | null): c is TokenCredential {
+    return c !== null && 'token' in c;
+}
+
+export function isClientCertCredential(c: Credential | null): c is ClientCertCredential {
+    return c !== null && 'clientKeyData' in c && 'clientCertificateData' in c;
+}
 
 export abstract class Authenticator {
-    protected cache: { [key: string]: Credentials };
+    protected cache: { [key: string]: Credential };
 
     constructor() {
         this.cache = {};
@@ -29,5 +35,5 @@ export abstract class Authenticator {
     }
 
     public abstract isAuthProvider(user: User): boolean;
-    public abstract getCredentials(user: User): Credentials | null;
+    public abstract getCredential(user: User): Credential | null;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,33 @@
 import { User } from './config_types';
 
-export interface Authenticator {
-    isAuthProvider(user: User): boolean;
-    getToken(user: User): string | null;
+interface CredentialsBase {
+    expirationTimestamp?: string;
+}
+
+export interface TokenCredentials extends CredentialsBase {
+    type: 'token';
+    token: string;
+}
+
+export interface ClientCertCredentials extends CredentialsBase {
+    type: 'client-cert';
+    clientCertificateData: string;
+    clientKeyData: string;
+}
+
+export type Credentials = TokenCredentials | ClientCertCredentials;
+
+export abstract class Authenticator {
+    protected cache: { [key: string]: Credentials };
+
+    constructor() {
+        this.cache = {};
+    }
+
+    public clearCache() {
+        this.cache = {};
+    }
+
+    public abstract isAuthProvider(user: User): boolean;
+    public abstract getCredentials(user: User): Credentials | null;
 }

--- a/src/cloud_auth.ts
+++ b/src/cloud_auth.ts
@@ -1,7 +1,7 @@
 import * as jsonpath from 'jsonpath-plus';
 import * as shelljs from 'shelljs';
 
-import { Authenticator, TokenCredentials } from './auth';
+import { Authenticator, TokenCredential } from './auth';
 import { User } from './config_types';
 
 /* FIXME: maybe we can extend the User and User.authProvider type to have a proper type.
@@ -24,13 +24,12 @@ export class CloudAuth extends Authenticator {
         return user.authProvider.name === 'azure' || user.authProvider.name === 'gcp';
     }
 
-    public getCredentials(user: User): TokenCredentials {
+    public getCredential(user: User): TokenCredential {
         const config = user.authProvider.config;
         if (this.isExpired(config)) {
             this.updateAccessToken(config);
         }
         return {
-            type: 'token',
             token: config['access-token'],
         };
     }

--- a/src/cloud_auth.ts
+++ b/src/cloud_auth.ts
@@ -1,7 +1,7 @@
 import * as jsonpath from 'jsonpath-plus';
 import * as shelljs from 'shelljs';
 
-import { Authenticator } from './auth';
+import { Authenticator, TokenCredentials } from './auth';
 import { User } from './config_types';
 
 /* FIXME: maybe we can extend the User and User.authProvider type to have a proper type.
@@ -16,7 +16,7 @@ interface Config {
     ['expiry-key']: string;
     ['access-token']?: string;
 }
-export class CloudAuth implements Authenticator {
+export class CloudAuth extends Authenticator {
     public isAuthProvider(user: User): boolean {
         if (!user || !user.authProvider) {
             return false;
@@ -24,12 +24,15 @@ export class CloudAuth implements Authenticator {
         return user.authProvider.name === 'azure' || user.authProvider.name === 'gcp';
     }
 
-    public getToken(user: User): string | null {
+    public getCredentials(user: User): TokenCredentials {
         const config = user.authProvider.config;
         if (this.isExpired(config)) {
             this.updateAccessToken(config);
         }
-        return 'Bearer ' + config['access-token'];
+        return {
+            type: 'token',
+            token: config['access-token'],
+        };
     }
 
     private isExpired(config: Config) {

--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -1,6 +1,6 @@
 import * as shell from 'shelljs';
 
-import { Authenticator, Credentials } from './auth';
+import { Authenticator } from './auth';
 import { User } from './config_types';
 
 export class ExecAuth extends Authenticator {
@@ -21,7 +21,7 @@ export class ExecAuth extends Authenticator {
         );
     }
 
-    public getCredentials(user: User) {
+    public getCredential(user: User) {
         // TODO: Add a unit test for token caching.
         // TODO: Move caching logic into base class
         const cached = this.cache[user.name];
@@ -62,21 +62,7 @@ export class ExecAuth extends Authenticator {
         const result = this.execFn(cmd, opts);
         if (result.code === 0) {
             const obj = JSON.parse(result.stdout);
-            const creds = obj.status;
-
-            // Explicitly setting types here, for type-safety
-            if (creds.token) {
-                this.cache[user.name] = {
-                    type: 'token',
-                    ...creds,
-                };
-            } else if (creds.clientKeyData) {
-                this.cache[user.name] = {
-                    type: 'client-cert',
-                    ...creds,
-                };
-            }
-
+            this.cache[user.name] = obj.status;
             return this.cache[user.name];
         }
         throw new Error(result.stderr);

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -13,7 +13,7 @@ describe('ExecAuth', () => {
             } as shell.ShellReturnValue;
         };
 
-        const creds = auth.getCredentials({
+        const creds = auth.getCredential({
             name: 'user',
             authProvider: {
                 config: {
@@ -23,7 +23,7 @@ describe('ExecAuth', () => {
                 },
             },
         });
-        expect(creds).to.eql({ type: 'token', token: 'foo' });
+        expect(creds).to.eql({ token: 'foo' });
     });
 
     it('should accept client cert credentials', async () => {
@@ -35,7 +35,7 @@ describe('ExecAuth', () => {
             } as shell.ShellReturnValue;
         };
 
-        const creds = auth.getCredentials({
+        const creds = auth.getCredential({
             name: 'user',
             authProvider: {
                 config: {
@@ -45,7 +45,7 @@ describe('ExecAuth', () => {
                 },
             },
         });
-        expect(creds).to.eql({ type: 'client-cert', clientKeyData: 'foo', clientCertificateData: 'bar' });
+        expect(creds).to.eql({ clientKeyData: 'foo', clientCertificateData: 'bar' });
     });
 
     it('should exec with env vars', async () => {
@@ -59,7 +59,7 @@ describe('ExecAuth', () => {
             } as shell.ShellReturnValue;
         };
         process.env.BLABBLE = 'flubble';
-        auth.getCredentials({
+        auth.getCredential({
             name: 'user',
             authProvider: {
                 config: {

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -6,14 +6,14 @@ import { ExecAuth } from './exec_auth';
 describe('ExecAuth', () => {
     it('should correctly exec', async () => {
         const auth = new ExecAuth();
-        (auth as any).execFn = (command: string, opts: shell.ExecOpts): shell.ShellReturnValue => {
+        (auth as any).execFn = (): shell.ShellReturnValue => {
             return {
                 code: 0,
                 stdout: JSON.stringify({ status: { token: 'foo' } }),
             } as shell.ShellReturnValue;
         };
 
-        const token = auth.getToken({
+        const creds = auth.getCredentials({
             name: 'user',
             authProvider: {
                 config: {
@@ -23,7 +23,29 @@ describe('ExecAuth', () => {
                 },
             },
         });
-        expect(token).to.equal('Bearer foo');
+        expect(creds).to.eql({ type: 'token', token: 'foo' });
+    });
+
+    it('should accept client cert credentials', async () => {
+        const auth = new ExecAuth();
+        (auth as any).execFn = (): shell.ShellReturnValue => {
+            return {
+                code: 0,
+                stdout: JSON.stringify({ status: { clientKeyData: 'foo', clientCertificateData: 'bar' } }),
+            } as shell.ShellReturnValue;
+        };
+
+        const creds = auth.getCredentials({
+            name: 'user',
+            authProvider: {
+                config: {
+                    exec: {
+                        command: 'echo',
+                    },
+                },
+            },
+        });
+        expect(creds).to.eql({ type: 'client-cert', clientKeyData: 'foo', clientCertificateData: 'bar' });
     });
 
     it('should exec with env vars', async () => {
@@ -37,7 +59,7 @@ describe('ExecAuth', () => {
             } as shell.ShellReturnValue;
         };
         process.env.BLABBLE = 'flubble';
-        const token = auth.getToken({
+        auth.getCredentials({
             name: 'user',
             authProvider: {
                 config: {

--- a/src/oidc_auth.ts
+++ b/src/oidc_auth.ts
@@ -1,7 +1,7 @@
-import { Authenticator } from './auth';
+import { Authenticator, TokenCredentials } from './auth';
 import { User } from './config_types';
 
-export class OpenIDConnectAuth implements Authenticator {
+export class OpenIDConnectAuth extends Authenticator {
     public isAuthProvider(user: User): boolean {
         if (!user.authProvider) {
             return false;
@@ -9,12 +9,14 @@ export class OpenIDConnectAuth implements Authenticator {
         return user.authProvider.name === 'oidc';
     }
 
-    public getToken(user: User): string | null {
+    public getCredentials(user: User): TokenCredentials | null {
         if (!user.authProvider.config || !user.authProvider.config['id-token']) {
             return null;
         }
         // TODO: Handle expiration and refresh here...
-        // TODO: Extract the 'Bearer ' to config.ts?
-        return `Bearer ${user.authProvider.config['id-token']}`;
+        return {
+            type: 'token',
+            token: user.authProvider.config['id-token'],
+        };
     }
 }

--- a/src/oidc_auth.ts
+++ b/src/oidc_auth.ts
@@ -1,4 +1,4 @@
-import { Authenticator, TokenCredentials } from './auth';
+import { Authenticator, TokenCredential } from './auth';
 import { User } from './config_types';
 
 export class OpenIDConnectAuth extends Authenticator {
@@ -9,13 +9,12 @@ export class OpenIDConnectAuth extends Authenticator {
         return user.authProvider.name === 'oidc';
     }
 
-    public getCredentials(user: User): TokenCredentials | null {
+    public getCredential(user: User): TokenCredential | null {
         if (!user.authProvider.config || !user.authProvider.config['id-token']) {
             return null;
         }
         // TODO: Handle expiration and refresh here...
         return {
-            type: 'token',
             token: user.authProvider.config['id-token'],
         };
     }

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -42,7 +42,7 @@ describe('OIDCAuth', () => {
             },
         } as User;
 
-        expect(auth.getToken(user)).to.equal(`Bearer ${token}`);
+        expect(auth.getCredentials(user)).to.eql({ type: 'token', token });
     });
 
     it('get null if token missing', () => {
@@ -53,6 +53,6 @@ describe('OIDCAuth', () => {
             },
         } as User;
 
-        expect(auth.getToken(user)).to.equal(null);
+        expect(auth.getCredentials(user)).to.equal(null);
     });
 });

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -42,7 +42,7 @@ describe('OIDCAuth', () => {
             },
         } as User;
 
-        expect(auth.getCredentials(user)).to.eql({ type: 'token', token });
+        expect(auth.getCredential(user)).to.eql({ token });
     });
 
     it('get null if token missing', () => {
@@ -53,6 +53,6 @@ describe('OIDCAuth', () => {
             },
         } as User;
 
-        expect(auth.getCredentials(user)).to.equal(null);
+        expect(auth.getCredential(user)).to.equal(null);
     });
 });


### PR DESCRIPTION
Needed this to support authenticating with DigitalOcean K8s clusters.

Took a little bit of refactoring on the Authenticator interface (incl. making it an abstract class instead of an interface), but nothing too drastic.