### PR TITLE
improve error handling in watch by checking response

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -67,6 +67,8 @@ export class Watch {
         const req = this.requestImpl.webRequest(requestOptions, (error, response, body) => {
             if (error) {
                 done(error);
+            } else if (response && response.statusCode !== 200) {
+                done(new Error(response.StatusMessage));
             } else {
                 done(null);
             }


### PR DESCRIPTION
Ran into a bug with watch where it was sending undefined, undefined to the 'on data' callback. Looks like the request response isn't being checked. Fixes #291.