### PR TITLE
Fixes property name in V1beta1CustomResourceColumnDefinition

### DIFF
--- a/src/gen/model/v1beta1CustomResourceColumnDefinition.ts
+++ b/src/gen/model/v1beta1CustomResourceColumnDefinition.ts
@@ -18,7 +18,7 @@ export class V1beta1CustomResourceColumnDefinition {
     /**
     * JSONPath is a simple JSON path, i.e. with array notation.
     */
-    'jSONPath': string;
+    'JSONPath': string;
     /**
     * description is a human readable description of this column.
     */
@@ -44,7 +44,7 @@ export class V1beta1CustomResourceColumnDefinition {
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "jSONPath",
+            "name": "JSONPath",
             "baseName": "JSONPath",
             "type": "string"
         },


### PR DESCRIPTION
Fixes issue with deploying, e.g. cert-manager (https://github.com/jetstack/cert-manager/releases/download/v0.9.0/cert-manager.yaml)

"JSONPath" starts with capital "J" (ref. https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions/types.go#L204)