### PR TITLE
openapi-generator compiled code regenerated on 2019-08-05T09:13:38Z

### DIFF
--- a/src/gen/model/runtimeRawExtension.ts
+++ b/src/gen/model/runtimeRawExtension.ts
@@ -18,13 +18,13 @@ export class RuntimeRawExtension {
     /**
     * Raw is the underlying serialization of this object.
     */
-    'raw': string;
+    'Raw': string;
 
     static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "raw",
+            "name": "Raw",
             "baseName": "Raw",
             "type": "string"
         }    ];

--- a/src/gen/model/v1DaemonEndpoint.ts
+++ b/src/gen/model/v1DaemonEndpoint.ts
@@ -18,13 +18,13 @@ export class V1DaemonEndpoint {
     /**
     * Port number of the given endpoint.
     */
-    'port': number;
+    'Port': number;
 
     static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "port",
+            "name": "Port",
             "baseName": "Port",
             "type": "number"
         }    ];

--- a/src/gen/model/v1beta1CustomResourceColumnDefinition.ts
+++ b/src/gen/model/v1beta1CustomResourceColumnDefinition.ts
@@ -18,7 +18,7 @@ export class V1beta1CustomResourceColumnDefinition {
     /**
     * JSONPath is a simple JSON path, i.e. with array notation.
     */
-    'jSONPath': string;
+    'JSONPath': string;
     /**
     * description is a human readable description of this column.
     */
@@ -44,7 +44,7 @@ export class V1beta1CustomResourceColumnDefinition {
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "jSONPath",
+            "name": "JSONPath",
             "baseName": "JSONPath",
             "type": "string"
         },


### PR DESCRIPTION
Updates openapi-generator compiled APIs.

This fixes issue in _V1beta1CustomResourceColumnDefinition_. Deploying, e.g. cert-manager (https://github.com/jetstack/cert-manager/releases/download/v0.9.0/cert-manager.yaml) failed (wrong case of _JSONPath_ property).

Ref. #314