### PR TITLE
Fixes path for openapi-generator output in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ npm install
 cd ../
 git clone https://github.com/kubernetes-client/gen
 cd javascript
-../gen/openapi/typescript.sh src settings
+../gen/openapi/typescript.sh src/gen settings
 ```
 
 ## Formatting


### PR DESCRIPTION
Generated code is under _/src/gen_, not just _/src_