### PR TITLE
Add 'off' method to ListWatch and Informer which allows for the removal of callbacks

### DIFF
--- a/src/informer.ts
+++ b/src/informer.ts
@@ -18,6 +18,7 @@ export const DELETE: string = 'delete';
 
 export interface Informer<T> {
     on(verb: string, fn: ObjectCallback<T>);
+    off(verb: string, fn: ObjectCallback<T>);
     start();
 }
 


### PR DESCRIPTION
Resolves #322 

**Why was a call to slice on each array added before passing to calling functions?**

Without it, the second test added, "mutating handlers in a callback should not affect those which remain", will fail. The calling functions use Array.prototype.forEach. From MDN 

> If elements that are already visited are removed (e.g. using shift()) during the iteration, later elements will be skipped

**Will slice be slow?**
Slice makes a shallow copy of the array, its linear with the number of callbacks added for a particular verb. Overhead should be minimal. If it is a concern, a more complex solution could be devised where .on and .off do not write to the callbackCaches during a forEach, however I prefered simplicity.

**Why was the initialization of the callbackCache verbs moved to the constructor**
Without it, more complex semantics are needed to determine if it is safe to call .slice in the various locations (i.e. callbackCache[VERB] may be null and .slice would fail without a check). 

I think this centralizes the location of verb checking now that it happens in two locations nicely
