### PR TITLE
Use command as quoted string in CloudAuth

### DIFF
--- a/src/cloud_auth.ts
+++ b/src/cloud_auth.ts
@@ -63,6 +63,8 @@ export class CloudAuth implements Authenticator {
         if (!cmd) {
             throw new Error('Token is expired!');
         }
+        // Wrap cmd in quotes to make it cope with spaces in path
+        cmd = `"${cmd}"`;
         const args = config['cmd-args'];
         if (args) {
             cmd = cmd + ' ' + args;

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -792,14 +792,6 @@ describe('KubeConfig', () => {
             }
         });
         it('should exec succesfully with spaces in cmd', async () => {
-            /**
-             *
-             * to test this, symlink echo to dir that has spaces:
-             * mkdir -p /tmp/foo\ bar/
-             * ln -s /bin/echo /tmp/foo\ bar/echo
-             *
-             * FIXME: Figure out a "portable" way to dynamically do this sort of symlink as part of the test case
-             */
             const config = new KubeConfig();
             const token = 'token';
             const responseStr = `{"token":{"accessToken":"${token}"}}`;
@@ -807,9 +799,9 @@ describe('KubeConfig', () => {
                 { skipTLSVerify: false } as Cluster,
                 {
                     authProvider: {
-                        name: 'azure', // aplias to gcp too as they are both handled by CloudAuth class
+                        name: 'azure', // applies to gcp too as they are both handled by CloudAuth class
                         config: {
-                            'cmd-path': '/tmp/foo bar/echo',
+                            'cmd-path': path.join(__dirname, '..', 'test', 'echo space.js'),
                             'cmd-args': `'${responseStr}'`,
                             'token-key': '{.token.accessToken}',
                             'expiry-key': '{.token.token_expiry}',

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -4,9 +4,12 @@ import { dirname, join } from 'path';
 
 import { expect } from 'chai';
 import mockfs = require('mock-fs');
-import * as requestlib from 'request';
 import * as path from 'path';
+import * as requestlib from 'request';
 
+import * as filesystem from 'fs';
+import { fs } from 'mock-fs';
+import * as os from 'os';
 import { CoreV1Api } from './api';
 import { bufferFromFileOrString, findHomeDir, findObject, KubeConfig, makeAbsolutePath } from './config';
 import { Cluster, newClusters, newContexts, newUsers, User } from './config_types';
@@ -774,6 +777,39 @@ describe('KubeConfig', () => {
                         name: 'azure',
                         config: {
                             'cmd-path': 'echo',
+                            'cmd-args': `'${responseStr}'`,
+                            'token-key': '{.token.accessToken}',
+                            'expiry-key': '{.token.token_expiry}',
+                        },
+                    },
+                } as User,
+            );
+            const opts = {} as requestlib.Options;
+            await config.applyToRequest(opts);
+            expect(opts.headers).to.not.be.undefined;
+            if (opts.headers) {
+                expect(opts.headers.Authorization).to.equal(`Bearer ${token}`);
+            }
+        });
+        it('should exec succesfully with spaces in cmd', async () => {
+            /**
+             *
+             * to test this, symlink echo to dir that has spaces:
+             * mkdir -p /tmp/foo\ bar/
+             * ln -s /bin/echo /tmp/foo\ bar/echo
+             *
+             * FIXME: Figure out a "portable" way to dynamically do this sort of symlink as part of the test case
+             */
+            const config = new KubeConfig();
+            const token = 'token';
+            const responseStr = `{"token":{"accessToken":"${token}"}}`;
+            config.loadFromClusterAndUser(
+                { skipTLSVerify: false } as Cluster,
+                {
+                    authProvider: {
+                        name: 'azure', // aplias to gcp too as they are both handled by CloudAuth class
+                        config: {
+                            'cmd-path': '/tmp/foo bar/echo',
                             'cmd-args': `'${responseStr}'`,
                             'token-key': '{.token.accessToken}',
                             'expiry-key': '{.token.token_expiry}',

--- a/test/echo space.js
+++ b/test/echo space.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+// Just echo back all the args
+console.log(process.argv.slice(2).join(' '))


### PR DESCRIPTION
We faced a case where `gcloud` for some reason was installed in path that contains whitespaces. This results in slightly weird (but still perfectly working[1]) kubeconfig:
```
cmd-path: /Users/auser/exec -l /bin/bash/google-cloud-sdk/bin/gcloud
```

Now as the `CloudAuth` uses plain `child_process` for exec it naturally breaks in this case.

It used to work with 0.10.2 version, but seems https://github.com/kubernetes-client/javascript/commit/0055a50e954aef7013a30f2cc0617c6fab609204 broke it when `CloudAuth` was changed to use plain `child_process`.

I'd appreciate some pointers and ideas how to make the test case actually portable and without any need to manually first create symlinks. Would it make sense to dynamically create a symlink to `echo` in some temp dir with whitespaces in the name?

[1] `kubectl` works perfectly still, so did previous version of JS client as it used `execa`