### PR TITLE
fix patchNamespacedDeployment

### DIFF
--- a/src/gen/api/appsV1Api.ts
+++ b/src/gen/api/appsV1Api.ts
@@ -2878,7 +2878,7 @@ export class AppsV1Api {
             .replace('{' + 'name' + '}', encodeURIComponent(String(name)))
             .replace('{' + 'namespace' + '}', encodeURIComponent(String(namespace)));
         let localVarQueryParameters: any = {};
-        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarHeaderParams: any = (<any>Object).assign({'Content-Type':'application/strategic-merge-patch+json'}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
         // verify required parameter 'name' is not null or undefined


### PR DESCRIPTION
patchNamespacedDeployment fails with '415: Unsupported Media Type' when Content-Type is 'application/json'.
Updated the default Content-Type to application/strategic-merge-patch+json