### PR TITLE
Fix OIDC refresh token storage with user auth config

### DIFF
--- a/src/oidc_auth.ts
+++ b/src/oidc_auth.ts
@@ -51,6 +51,7 @@ export class OpenIDConnectAuth implements Authenticator {
         if (Date.now() / 1000 > this.currentTokenExpiration) {
             const newToken = await client.refresh(user.authProvider.config['refresh-token']);
             user.authProvider.config['id-token'] = newToken.id_token;
+            user.authProvider.config['refresh-token'] = newToken.refresh_token;
             this.currentTokenExpiration = newToken.expires_at || 0;
         }
         return user.authProvider.config['id-token'];

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -171,11 +171,14 @@ describe('OIDCAuth', () => {
                 return {
                     expires_at: newExpiration,
                     id_token: 'newToken',
+                    refresh_token: 'newRefreshToken',
                 };
             },
         });
         expect(opts.headers.Authorization).to.equal('Bearer newToken');
         expect((auth as any).currentTokenExpiration).to.equal(newExpiration);
+        // Check also the new refresh token sticks in the user config
+        expect(user.authProvider.config['refresh-token']).to.equal('newRefreshToken');
     });
 
     it('return a new token when the its the first time we see this user', async () => {


### PR DESCRIPTION
Previously the `refresh-token` was not persisted on the auth config at all. This rendered the whole OIDC auth pretty much broken, it could only work for a single refresh, after that the refresh token would have been used and on the next try the client would try to use already used token --> errors.

This PR makes the refresh token to be properly stored on the oidc auth config along with the real token on token refresh.