### PR TITLE
Don't require client-secret in OIDC authentication.

### DIFF
--- a/src/oidc_auth.ts
+++ b/src/oidc_auth.ts
@@ -33,11 +33,16 @@ export class OpenIDConnectAuth implements Authenticator {
     }
 
     private async getToken(user: User, overrideClient?: Client): Promise<string | null> {
+        if (!user.authProvider.config) {
+            return null;
+        }
+        if (!user.authProvider.config['client-secret']) {
+            user.authProvider.config['client-secret'] = '';
+        }
         if (
             !user.authProvider.config ||
             !user.authProvider.config['id-token'] ||
             !user.authProvider.config['client-id'] ||
-            !user.authProvider.config['client-secret'] ||
             !user.authProvider.config['refresh-token'] ||
             !user.authProvider.config['idp-issuer-url']
         ) {

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -70,7 +70,7 @@ describe('OIDCAuth', () => {
         expect(opts.headers.Authorization).to.be.undefined;
     });
 
-    it('authorization should be undefined if client-secret missing', async () => {
+    it('authorization should be work if client-secret missing', async () => {
         const user = {
             authProvider: {
                 name: 'oidc',
@@ -85,8 +85,9 @@ describe('OIDCAuth', () => {
 
         const opts = {} as request.Options;
         opts.headers = [];
-        await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.be.undefined;
+        (auth as any).currentTokenExpiration = Date.now() / 1000 + 1000;
+        await auth.applyAuthentication(user, opts, {});
+        expect(opts.headers.Authorization).to.equal('Bearer fakeToken');
     });
 
     it('authorization should be undefined if refresh-token missing', async () => {


### PR DESCRIPTION
Closes #361 