### PR TITLE
Fix example to only list from one namespace.

### DIFF
--- a/examples/typescript/informer/informer.ts
+++ b/examples/typescript/informer/informer.ts
@@ -6,7 +6,7 @@ kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-const listFn = () => k8sApi.listPodForAllNamespaces();
+const listFn = () => k8sApi.listNamespacedPod('default');
 
 const informer = k8s.makeInformer(kc, '/api/v1/namespaces/default/pods', listFn);
 


### PR DESCRIPTION
Fixes a bug raised in #377 