### PR TITLE
Add error handling to informer

### DIFF
--- a/examples/typescript/informer/informer.ts
+++ b/examples/typescript/informer/informer.ts
@@ -13,5 +13,12 @@ const informer = k8s.makeInformer(kc, '/api/v1/namespaces/default/pods', listFn)
 informer.on('add', (obj: k8s.V1Pod) => { console.log(`Added: ${obj.metadata!.name}`); });
 informer.on('update', (obj: k8s.V1Pod) => { console.log(`Updated: ${obj.metadata!.name}`); });
 informer.on('delete', (obj: k8s.V1Pod) => { console.log(`Deleted: ${obj.metadata!.name}`); });
+informer.on('error', (err: k8s.V1Pod) => {
+  console.error(err);
+  // Restart informer after 5sec
+  setTimeout(() => {
+    informer.start();
+  }, 5000);
+});
 
 informer.start();

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import { ADD, DELETE, Informer, ListPromise, ObjectCallback, UPDATE } from './informer';
+import { ADD, DELETE, ERROR, Informer, ListPromise, ObjectCallback, UPDATE } from './informer';
 import { KubernetesObject } from './types';
 import { Watch } from './watch';
 
@@ -23,6 +23,7 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
         this.callbackCache[ADD] = [];
         this.callbackCache[UPDATE] = [];
         this.callbackCache[DELETE] = [];
+        this.callbackCache[ERROR] = [];
         if (autoStart) {
             this.doneHandler(null);
         }
@@ -68,6 +69,10 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
     }
 
     private async doneHandler(err: any) {
+        if (err) {
+            this.callbackCache[ERROR].forEach((elt: ObjectCallback<T>) => elt(err));
+            return;
+        }
         const promise = this.listFn();
         const result = await promise;
         const list = result.body;

--- a/src/informer.ts
+++ b/src/informer.ts
@@ -15,6 +15,7 @@ export type ListPromise<T extends KubernetesObject> = () => Promise<{
 export const ADD: string = 'add';
 export const UPDATE: string = 'update';
 export const DELETE: string = 'delete';
+export const ERROR: string = 'error';
 
 export interface Informer<T> {
     on(verb: string, fn: ObjectCallback<T>);


### PR DESCRIPTION
Adds a new callback type of `error` for informers so that errors received by the cache.doneHandler, e.g. `Unauthorized` or `Not Found` are surfaced and not lost.