### PR TITLE
Fix watch api missing Authentication when using an async Authenticator

### DIFF
--- a/examples/typescript/watch/watch-example.ts
+++ b/examples/typescript/watch/watch-example.ts
@@ -4,7 +4,7 @@ const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const watch = new k8s.Watch(kc);
-const req = watch.watch('/api/v1/namespaces',
+watch.watch('/api/v1/namespaces',
     // optional query parameters can go here.
     {},
     // callback is called for each received object.
@@ -29,7 +29,8 @@ const req = watch.watch('/api/v1/namespaces',
     (err) => {
         // tslint:disable-next-line:no-console
         console.log(err);
-    });
-
-// watch returns a request object which you can use to abort the watch.
-setTimeout(() => { req.abort(); }, 10 * 1000);
+    })
+.then((req) => {
+    // watch returns a request object which you can use to abort the watch.
+    setTimeout(() => { req.abort(); }, 10 * 1000);
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -73,7 +73,7 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
         const list = result.body;
         deleteItems(this.objects, list.items, this.callbackCache[DELETE].slice());
         this.addOrUpdateItems(list.items);
-        this.watch.watch(
+        await this.watch.watch(
             this.path,
             { resourceVersion: list.metadata!.resourceVersion },
             this.watchHandler.bind(this),

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -31,12 +31,12 @@ export class Watch {
         }
     }
 
-    public watch(
+    public async watch(
         path: string,
         queryParams: any,
         callback: (phase: string, obj: any) => void,
         done: (err: any) => void,
-    ): any {
+    ): Promise<any> {
         const cluster = this.config.getCurrentCluster();
         if (!cluster) {
             throw new Error('No currently active cluster');
@@ -54,7 +54,7 @@ export class Watch {
             useQuerystring: true,
             json: true,
         };
-        this.config.applyToRequest(requestOptions);
+        await this.config.applyToRequest(requestOptions);
 
         const stream = byline.createStream();
         stream.on('data', (line) => {
@@ -69,6 +69,7 @@ export class Watch {
             done(err);
         });
         stream.on('close', () => done(null));
+
         const req = this.requestImpl.webRequest(requestOptions, (error, response, body) => {
             if (error) {
                 done(error);

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -39,7 +39,7 @@ describe('Watch', () => {
         const watch = new Watch(kc);
     });
 
-    it('should watch correctly', () => {
+    it('should watch correctly', async () => {
         const kc = new KubeConfig();
         Object.assign(kc, fakeConfig);
         const fakeRequestor = mock(DefaultRequest);
@@ -75,7 +75,7 @@ describe('Watch', () => {
         let doneCalled = false;
         let doneErr: any;
 
-        watch.watch(
+        await watch.watch(
             path,
             {},
             (phase: string, obj: string) => {
@@ -112,7 +112,7 @@ describe('Watch', () => {
         expect(doneErr).to.deep.equal(errIn);
     });
 
-    it('should handle errors correctly', () => {
+    it('should handle errors correctly', async () => {
         const kc = new KubeConfig();
         Object.assign(kc, fakeConfig);
         const fakeRequestor = mock(DefaultRequest);
@@ -142,7 +142,7 @@ describe('Watch', () => {
         let doneCalled = false;
         let doneErr: any;
 
-        watch.watch(
+        await watch.watch(
             path,
             {},
             (phase: string, obj: string) => {
@@ -171,7 +171,7 @@ describe('Watch', () => {
         expect(doneErr).to.deep.equal(errIn);
     });
 
-    it('should handle server side close correctly', () => {
+    it('should handle server side close correctly', async () => {
         const kc = new KubeConfig();
         Object.assign(kc, fakeConfig);
         const fakeRequestor = mock(DefaultRequest);
@@ -200,7 +200,7 @@ describe('Watch', () => {
         let doneCalled = false;
         let doneErr: any;
 
-        watch.watch(
+        await watch.watch(
             path,
             {},
             (phase: string, obj: string) => {
@@ -229,7 +229,7 @@ describe('Watch', () => {
         expect(doneErr).to.be.null;
     });
 
-    it('should ignore JSON parse errors', () => {
+    it('should ignore JSON parse errors', async () => {
         const kc = new KubeConfig();
         Object.assign(kc, fakeConfig);
         const fakeRequestor = mock(DefaultRequest);
@@ -256,7 +256,7 @@ describe('Watch', () => {
         const receivedTypes: string[] = [];
         const receivedObjects: string[] = [];
 
-        watch.watch(
+        await watch.watch(
             path,
             {},
             (recievedType: string, recievedObject: string) => {


### PR DESCRIPTION
This corrects an issue which causes the `watch` api to receive `Unauthorized` errors when using an Authenticator which is asynchronous such as `oidc_auth` due to the request being sent without an `Authorization:` header.