### PR TITLE
Apply authentication when streaming logs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -401,7 +401,7 @@ export class KubeConfig {
         });
 
         if (!opts.headers) {
-            opts.headers = [];
+            opts.headers = {};
         }
         if (authenticator) {
             await authenticator.applyAuthentication(user, opts);

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -212,7 +212,7 @@ describe('KubeConfig', () => {
             kc.applytoHTTPSOptions(opts);
 
             expect(opts).to.deep.equal({
-                headers: [],
+                headers: {},
                 ca: new Buffer('CADATA2', 'utf-8'),
                 cert: new Buffer('USER2_CADATA', 'utf-8'),
                 key: new Buffer('USER2_CKDATA', 'utf-8'),
@@ -229,7 +229,7 @@ describe('KubeConfig', () => {
             };
             await kc.applyToRequest(opts);
             expect(opts).to.deep.equal({
-                headers: [],
+                headers: {},
                 ca: new Buffer('CADATA2', 'utf-8'),
                 auth: {
                     username: 'foo',

--- a/src/log.ts
+++ b/src/log.ts
@@ -51,14 +51,14 @@ export class Log {
         this.config = config;
     }
 
-    public log(
+    public async log(
         namespace: string,
         podName: string,
         containerName: string,
         stream: Writable,
         done: (err: any) => void,
         options: LogOptions = {},
-    ): request.Request {
+    ): Promise<request.Request> {
         const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log`;
 
         const cluster = this.config.getCurrentCluster();
@@ -75,7 +75,7 @@ export class Log {
             },
             uri: url,
         };
-        this.config.applyToRequest(requestOptions);
+        await this.config.applyToRequest(requestOptions);
 
         const req = request(requestOptions, (error, response, body) => {
             if (error) {


### PR DESCRIPTION
This fixes #405 which is caused by `Config.applyToRequest` being an asynchronous function and thus should be awaited on. Method `Log.log`, which calls this function, doesn't await for the authentication to be properly applied and causes API call sent without any credentials, which resulted in 401 response from the server.

This change converts `Log.log` method into `async` which returns `Promise<request.Request>` and awaits for `Config.applyToRequest` to complete before proceeding.