### PR TITLE
Fixed missing variable initialization

### DIFF
--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -83,7 +83,7 @@ export class WebSocketHandler implements WebSocketInterface {
         }
 
         let queue: Promise<void> = Promise.resolve();
-        let ws: WebSocket | null;
+        let ws: WebSocket | null = null;
 
         async function processData(data): Promise<void> {
             const buff = Buffer.alloc(data.length + 1);


### PR DESCRIPTION
Since ws was never initialized on line 86 it defaulted to undefined which means that if(ws !== null) on line 100 becomes true