### PR TITLE
fix: add defaultHeaders field to ApiType interface

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -419,7 +419,8 @@ export class KubeConfig {
 }
 
 export interface ApiType {
-    setDefaultAuthentication(config: api.Authentication);
+    defaultHeaders: any;
+    setDefaultAuthentication(config: api.Authentication): void;
 }
 
 type ApiConstructor<T extends ApiType> = new (server: string) => T;


### PR DESCRIPTION
Fix for #423 

I want to access defaultHeaders through this generic type within a generic API client factory.