### PR TITLE
Add KubernetesObjectApi

### DIFF
--- a/examples/typescript/apply/apply-example.ts
+++ b/examples/typescript/apply/apply-example.ts
@@ -1,0 +1,43 @@
+import * as k8s from '@kubernetes/client-node';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { promisify } from 'util';
+
+/**
+ * Replicate the functionality of `kubectl apply`.  That is, create the resources defined in the `specFile` if they do
+ * not exist, patch them if they do exist.
+ *
+ * @param specPath File system path to a YAML Kubernetes spec.
+ * @return Array of resources created
+ */
+export async function apply(specPath: string): Promise<k8s.KubernetesObject[]> {
+    const kc = new k8s.KubeConfig();
+    kc.loadFromDefault();
+    const client = k8s.KubernetesObjectApi.makeApiClient(kc);
+    const fsReadFileP = promisify(fs.readFile);
+    const specString = await fsReadFileP(specPath, 'utf8');
+    const specs: k8s.KubernetesObject[] = yaml.safeLoadAll(specString);
+    const validSpecs = specs.filter((s) => s && s.kind && s.metadata);
+    const created: k8s.KubernetesObject[] = [];
+    for (const spec of validSpecs) {
+        // this is to convince the old version of TypeScript that metadata exists even though we already filtered specs
+        // without metadata out
+        spec.metadata = spec.metadata || {};
+        spec.metadata.annotations = spec.metadata.annotations || {};
+        delete spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'];
+        spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(spec);
+        try {
+            // try to get the resource, if it does not exist an error will be thrown and we will end up in the catch
+            // block.
+            await client.read(spec);
+            // we got the resource, so it exists, so patch it
+            const response = await client.patch(spec);
+            created.push(response.body);
+        } catch (e) {
+            // we did not get the resource, so it does not exist, so create it
+            const response = await client.create(spec);
+            created.push(response.body);
+        }
+    }
+    return created;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export * from './yaml';
 export * from './log';
 export * from './informer';
 export * from './top';
+export * from './object';

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,0 +1,538 @@
+import * as http from 'http';
+import * as request from 'request';
+import {
+    ApisApi,
+    HttpError,
+    ObjectSerializer,
+    V1APIResource,
+    V1APIResourceList,
+    V1DeleteOptions,
+    V1Status,
+} from './api';
+import { KubeConfig } from './config';
+import { KubernetesListObject, KubernetesObject } from './types';
+
+/** Union type of body types returned by KubernetesObjectApi. */
+type KubernetesObjectResponseBody =
+    | KubernetesObject
+    | KubernetesListObject<KubernetesObject>
+    | V1Status
+    | V1APIResourceList;
+
+/** Kubernetes API verbs. */
+type KubernetesApiAction = 'create' | 'delete' | 'patch' | 'read' | 'replace';
+
+/**
+ * Valid Content-Type header values for patch operations.  See
+ * https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
+ * for details.
+ */
+enum KubernetesPatchStrategies {
+    /** Diff-like JSON format. */
+    JsonPatch = 'application/json-patch+json',
+    /** Simple merge. */
+    MergePatch = 'application/merge-patch+json',
+    /** Merge with different strategies depending on field metadata. */
+    StrategicMergePatch = 'application/strategic-merge-patch+json',
+}
+
+/**
+ * Dynamically construct Kubernetes API request URIs so client does not have to know what type of object it is acting
+ * on.
+ */
+export class KubernetesObjectApi extends ApisApi {
+    /**
+     * Create a KubernetesObjectApi object from the provided KubeConfig.  This method should be used rather than
+     * [[KubeConfig.makeApiClient]] so we can properly determine the default namespace if one is provided by the current
+     * context.
+     *
+     * @param kc Valid Kubernetes config
+     * @return Properly instantiated [[KubernetesObjectApi]] object
+     */
+    public static makeApiClient(kc: KubeConfig): KubernetesObjectApi {
+        const client = kc.makeApiClient(KubernetesObjectApi);
+        if (kc.currentContext) {
+            const currentContext = kc.getContextObject(kc.currentContext);
+            if (currentContext && currentContext.namespace) {
+                client.defaultNamespace = currentContext.namespace;
+            }
+        }
+        return client;
+    }
+
+    /**
+     * Return whether the name of the resource should be appended to the API URI path.  When creating resources, it is
+     * not appended.
+     *
+     * @param action API action, see [[K8sApiAction]]
+     * @return true if name should be appended to URI
+     */
+    protected static appendName(action: KubernetesApiAction): boolean {
+        return action !== 'create';
+    }
+
+    /** Default default namespace, so to speak. */
+    private static readonly defaultDefaultNamespace = 'default';
+
+    /** Initialize the default namespace.  May be overwritten by context. */
+    protected defaultNamespace: string = KubernetesObjectApi.defaultDefaultNamespace;
+
+    /**
+     * Create any Kubernetes resource.
+     * @param spec Kubernetes resource spec.
+     * @param pretty If \&#39;true\&#39;, then the output is pretty printed.
+     * @param dryRun When present, indicates that modifications should not be persisted. An invalid or unrecognized
+     *        dryRun directive will result in an error response and no further processing of the request. Valid values
+     *        are: - All: all dry run stages will be processed
+     * @param fieldManager fieldManager is a name associated with the actor or entity that is making these changes. The
+     *        value must be less than or 128 characters long, and only contain printable characters, as defined by
+     *        https://golang.org/pkg/unicode/#IsPrint.
+     * @param options Optional headers to use in the request.
+     * @return Promise containing the request response and [[KubernetesObject]].
+     */
+    public async create(
+        spec: KubernetesObject,
+        pretty?: string,
+        dryRun?: string,
+        fieldManager?: string,
+        options: { headers: { [name: string]: string } } = { headers: {} },
+    ): Promise<{ body: KubernetesObject; response: http.IncomingMessage }> {
+        // verify required parameter 'spec' is not null or undefined
+        if (spec === null || spec === undefined) {
+            throw new Error('Required parameter spec was null or undefined when calling create.');
+        }
+
+        const localVarPath = await this.specUriPath(spec, 'create');
+        const localVarQueryParameters: any = {};
+        const localVarHeaderParams = this.generateHeaders(options.headers);
+
+        if (pretty !== undefined) {
+            localVarQueryParameters.pretty = ObjectSerializer.serialize(pretty, 'string');
+        }
+
+        if (dryRun !== undefined) {
+            localVarQueryParameters.dryRun = ObjectSerializer.serialize(dryRun, 'string');
+        }
+
+        if (fieldManager !== undefined) {
+            localVarQueryParameters.fieldManager = ObjectSerializer.serialize(fieldManager, 'string');
+        }
+
+        const localVarRequestOptions: request.Options = {
+            method: 'POST',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: ObjectSerializer.serialize(spec, 'KubernetesObject'),
+        };
+
+        return this.requestPromise(localVarRequestOptions);
+    }
+
+    /**
+     * Delete any Kubernetes resource.
+     * @param spec Kubernetes resource spec
+     * @param pretty If \&#39;true\&#39;, then the output is pretty printed.
+     * @param dryRun When present, indicates that modifications should not be persisted. An invalid or unrecognized
+     *        dryRun directive will result in an error response and no further processing of the request. Valid values
+     *        are: - All: all dry run stages will be processed
+     * @param gracePeriodSeconds The duration in seconds before the object should be deleted. Value must be non-negative
+     *        integer. The value zero indicates delete immediately. If this value is nil, the default grace period for
+     *        the specified type will be used. Defaults to a per object value if not specified. zero means delete
+     *        immediately.
+     * @param orphanDependents Deprecated: please use the PropagationPolicy, this field will be deprecated in
+     *        1.7. Should the dependent objects be orphaned. If true/false, the \&quot;orphan\&quot; finalizer will be
+     *        added to/removed from the object\&#39;s finalizers list. Either this field or PropagationPolicy may be
+     *        set, but not both.
+     * @param propagationPolicy Whether and how garbage collection will be performed. Either this field or
+     *        OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in
+     *        the metadata.finalizers and the resource-specific default policy. Acceptable values are:
+     *        \&#39;Orphan\&#39; - orphan the dependents; \&#39;Background\&#39; - allow the garbage collector to delete
+     *        the dependents in the background; \&#39;Foreground\&#39; - a cascading policy that deletes all dependents
+     *        in the foreground.
+     * @param body See [[V1DeleteOptions]].
+     * @param options Optional headers to use in the request.
+     * @return Promise containing the request response and a Kubernetes [[V1Status]].
+     */
+    public async delete(
+        spec: KubernetesObject,
+        pretty?: string,
+        dryRun?: string,
+        gracePeriodSeconds?: number,
+        orphanDependents?: boolean,
+        propagationPolicy?: string,
+        body?: V1DeleteOptions,
+        options: { headers: { [name: string]: string } } = { headers: {} },
+    ): Promise<{ body: V1Status; response: http.IncomingMessage }> {
+        // verify required parameter 'spec' is not null or undefined
+        if (spec === null || spec === undefined) {
+            throw new Error('Required parameter spec was null or undefined when calling delete.');
+        }
+
+        const localVarPath = await this.specUriPath(spec, 'delete');
+        const localVarQueryParameters: any = {};
+        const localVarHeaderParams = this.generateHeaders(options.headers);
+
+        if (pretty !== undefined) {
+            localVarQueryParameters.pretty = ObjectSerializer.serialize(pretty, 'string');
+        }
+
+        if (dryRun !== undefined) {
+            localVarQueryParameters.dryRun = ObjectSerializer.serialize(dryRun, 'string');
+        }
+
+        if (gracePeriodSeconds !== undefined) {
+            localVarQueryParameters.gracePeriodSeconds = ObjectSerializer.serialize(
+                gracePeriodSeconds,
+                'number',
+            );
+        }
+
+        if (orphanDependents !== undefined) {
+            localVarQueryParameters.orphanDependents = ObjectSerializer.serialize(
+                orphanDependents,
+                'boolean',
+            );
+        }
+
+        if (propagationPolicy !== undefined) {
+            localVarQueryParameters.propagationPolicy = ObjectSerializer.serialize(
+                propagationPolicy,
+                'string',
+            );
+        }
+
+        const localVarRequestOptions: request.Options = {
+            method: 'DELETE',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: ObjectSerializer.serialize(body, 'V1DeleteOptions'),
+        };
+
+        return this.requestPromise<V1Status>(localVarRequestOptions, 'V1Status');
+    }
+
+    /**
+     * Patch any Kubernetes resource.
+     * @param spec Kubernetes resource spec
+     * @param pretty If \&#39;true\&#39;, then the output is pretty printed.
+     * @param dryRun When present, indicates that modifications should not be persisted. An invalid or unrecognized
+     *        dryRun directive will result in an error response and no further processing of the request. Valid values
+     *        are: - All: all dry run stages will be processed
+     * @param fieldManager fieldManager is a name associated with the actor or entity that is making these changes.  The
+     *        value must be less than or 128 characters long, and only contain printable characters, as defined by
+     *        https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests
+     *        (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch,
+     *        StrategicMergePatch).
+     * @param force Force is going to \&quot;force\&quot; Apply requests.  It means user will re-acquire conflicting
+     *        fields owned by other people. Force flag must be unset for non-apply patch requests.
+     * @param options Optional headers to use in the request.
+     * @return Promise containing the request response and [[KubernetesObject]].
+     */
+    public async patch(
+        spec: KubernetesObject,
+        pretty?: string,
+        dryRun?: string,
+        fieldManager?: string,
+        force?: boolean,
+        options: { headers: { [name: string]: string } } = { headers: {} },
+    ): Promise<{ body: KubernetesObject; response: http.IncomingMessage }> {
+        // verify required parameter 'spec' is not null or undefined
+        if (spec === null || spec === undefined) {
+            throw new Error('Required parameter spec was null or undefined when calling patch.');
+        }
+
+        const localVarPath = await this.specUriPath(spec, 'patch');
+        const localVarQueryParameters: any = {};
+        const localVarHeaderParams = this.generateHeaders(options.headers, 'PATCH');
+
+        if (pretty !== undefined) {
+            localVarQueryParameters.pretty = ObjectSerializer.serialize(pretty, 'string');
+        }
+
+        if (dryRun !== undefined) {
+            localVarQueryParameters.dryRun = ObjectSerializer.serialize(dryRun, 'string');
+        }
+
+        if (fieldManager !== undefined) {
+            localVarQueryParameters.fieldManager = ObjectSerializer.serialize(fieldManager, 'string');
+        }
+
+        if (force !== undefined) {
+            localVarQueryParameters.force = ObjectSerializer.serialize(force, 'boolean');
+        }
+
+        const localVarRequestOptions: request.Options = {
+            method: 'PATCH',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: ObjectSerializer.serialize(spec, 'object'),
+        };
+
+        return this.requestPromise(localVarRequestOptions);
+    }
+
+    /**
+     * Read any Kubernetes resource.
+     * @param spec Kubernetes resource spec
+     * @param pretty If \&#39;true\&#39;, then the output is pretty printed.
+     * @param exact Should the export be exact.  Exact export maintains cluster-specific fields like
+     *        \&#39;Namespace\&#39;. Deprecated. Planned for removal in 1.18.
+     * @param exportt Should this value be exported.  Export strips fields that a user can not
+     *        specify. Deprecated. Planned for removal in 1.18.
+     * @param options Optional headers to use in the request.
+     * @return Promise containing the request response and [[KubernetesObject]].
+     */
+    public async read(
+        spec: KubernetesObject,
+        pretty?: string,
+        exact?: boolean,
+        exportt?: boolean,
+        options: { headers: { [name: string]: string } } = { headers: {} },
+    ): Promise<{ body: KubernetesObject; response: http.IncomingMessage }> {
+        // verify required parameter 'spec' is not null or undefined
+        if (spec === null || spec === undefined) {
+            throw new Error('Required parameter spec was null or undefined when calling read.');
+        }
+
+        const localVarPath = await this.specUriPath(spec, 'read');
+        const localVarQueryParameters: any = {};
+        const localVarHeaderParams = this.generateHeaders(options.headers);
+
+        if (pretty !== undefined) {
+            localVarQueryParameters.pretty = ObjectSerializer.serialize(pretty, 'string');
+        }
+
+        if (exact !== undefined) {
+            localVarQueryParameters.exact = ObjectSerializer.serialize(exact, 'boolean');
+        }
+
+        if (exportt !== undefined) {
+            localVarQueryParameters.export = ObjectSerializer.serialize(exportt, 'boolean');
+        }
+
+        const localVarRequestOptions: request.Options = {
+            method: 'GET',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+        };
+
+        return this.requestPromise(localVarRequestOptions);
+    }
+
+    /**
+     * Replace any Kubernetes resource.
+     * @param spec Kubernetes resource spec
+     * @param pretty If \&#39;true\&#39;, then the output is pretty printed.
+     * @param dryRun When present, indicates that modifications should not be persisted. An invalid or unrecognized
+     *        dryRun directive will result in an error response and no further processing of the request. Valid values
+     *        are: - All: all dry run stages will be processed
+     * @param fieldManager fieldManager is a name associated with the actor or entity that is making these changes. The
+     *        value must be less than or 128 characters long, and only contain printable characters, as defined by
+     *        https://golang.org/pkg/unicode/#IsPrint.
+     * @param options Optional headers to use in the request.
+     * @return Promise containing the request response and [[KubernetesObject]].
+     */
+    public async replace(
+        spec: KubernetesObject,
+        pretty?: string,
+        dryRun?: string,
+        fieldManager?: string,
+        options: { headers: { [name: string]: string } } = { headers: {} },
+    ): Promise<{ body: KubernetesObject; response: http.IncomingMessage }> {
+        // verify required parameter 'spec' is not null or undefined
+        if (spec === null || spec === undefined) {
+            throw new Error('Required parameter spec was null or undefined when calling replace.');
+        }
+
+        const localVarPath = await this.specUriPath(spec, 'replace');
+        const localVarQueryParameters: any = {};
+        const localVarHeaderParams = this.generateHeaders(options.headers);
+
+        if (pretty !== undefined) {
+            localVarQueryParameters.pretty = ObjectSerializer.serialize(pretty, 'string');
+        }
+
+        if (dryRun !== undefined) {
+            localVarQueryParameters.dryRun = ObjectSerializer.serialize(dryRun, 'string');
+        }
+
+        if (fieldManager !== undefined) {
+            localVarQueryParameters.fieldManager = ObjectSerializer.serialize(fieldManager, 'string');
+        }
+
+        const localVarRequestOptions: request.Options = {
+            method: 'PUT',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: ObjectSerializer.serialize(spec, 'KubernetesObject'),
+        };
+
+        return this.requestPromise(localVarRequestOptions);
+    }
+
+    /**
+     * Use spec information to construct resource URI path.  If any required information in not provided, an Error is
+     * thrown.  If an `apiVersion` is not provided, 'v1' is used.  If a `metadata.namespace` is not provided for a
+     * request that requires one, the context default is used, if available, if not, 'default' is used.
+     *
+     * @param spec Kubernetes resource spec which must define kind and apiVersion properties.
+     * @param action API action, see [[K8sApiAction]].
+     * @return tail of resource-specific URI
+     */
+    protected async specUriPath(spec: KubernetesObject, action: KubernetesApiAction): Promise<string> {
+        if (!spec.kind) {
+            throw new Error('Required spec property kind is not set');
+        }
+        if (!spec.apiVersion) {
+            spec.apiVersion = 'v1';
+        }
+        if (!spec.metadata) {
+            spec.metadata = {};
+        }
+        const resource = await this.resource(spec.apiVersion, spec.kind);
+        if (!resource) {
+            throw new Error(`Unrecognized API version and kind: ${spec.apiVersion} ${spec.kind}`);
+        }
+        if (resource.namespaced && !spec.metadata.namespace) {
+            spec.metadata.namespace = this.defaultNamespace;
+        }
+        const parts = [this.apiVersionPath(spec.apiVersion)];
+        if (resource.namespaced && spec.metadata.namespace) {
+            parts.push('namespaces', encodeURIComponent(String(spec.metadata.namespace)));
+        }
+        parts.push(resource.name);
+        if (KubernetesObjectApi.appendName(action)) {
+            if (!spec.metadata.name) {
+                throw new Error('Required spec property name is not set');
+            }
+            parts.push(encodeURIComponent(String(spec.metadata.name)));
+        }
+        return parts.join('/').toLowerCase();
+    }
+
+    /** Return root of API path up to API version. */
+    protected apiVersionPath(apiVersion: string): string {
+        const api = apiVersion.includes('/') ? 'apis' : 'api';
+        return [this.basePath, api, apiVersion].join('/');
+    }
+
+    /**
+     * Merge default headers and provided headers, setting the 'Accept' header to 'application/json' and, if the
+     * `action` is 'PATCH', the 'Content-Type' header to [[KubernetesPatchStrategies.StrategicMergePatch]].  Both of
+     * these defaults can be overriden by values provided in `optionsHeaders`.
+     *
+     * @param optionHeaders Headers from method's options argument.
+     * @param action HTTP action headers are being generated for.
+     * @return Headers to use in request.
+     */
+    protected generateHeaders(
+        optionsHeaders: { [name: string]: string },
+        action: string = 'GET',
+    ): { [name: string]: string } {
+        const headers: { [name: string]: string } = Object.assign({}, this._defaultHeaders);
+        headers.accept = 'application/json';
+        if (action === 'PATCH') {
+            headers['content-type'] = KubernetesPatchStrategies.StrategicMergePatch;
+        }
+        Object.assign(headers, optionsHeaders);
+        return headers;
+    }
+
+    /**
+     * Get metadata from Kubernetes API for resources described by `kind` and `apiVersion`.  If it is unable to find the
+     * resource `kind` under the provided `apiVersion`, `undefined` is returned.
+     *
+     * @param apiVersion Kubernetes API version, e.g., 'v1' or 'apps/v1'.
+     * @param kind Kubernetes resource kind, e.g., 'Pod' or 'Namespace'.
+     * @return Promise of the resource metadata or `undefined` if the resource is not found.
+     */
+    protected async resource(apiVersion: string, kind: string): Promise<V1APIResource | undefined> {
+        // verify required parameter 'apiVersion' is not null or undefined
+        if (apiVersion === null || apiVersion === undefined) {
+            throw new Error('Required parameter apiVersion was null or undefined when calling resource');
+        }
+        // verify required parameter 'kind' is not null or undefined
+        if (kind === null || kind === undefined) {
+            throw new Error('Required parameter kind was null or undefined when calling resource');
+        }
+
+        const localVarPath = this.apiVersionPath(apiVersion);
+        const localVarQueryParameters: any = {};
+        const localVarHeaderParams = this.generateHeaders({});
+
+        const localVarRequestOptions: request.Options = {
+            method: 'GET',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+        };
+
+        try {
+            const getApiResponse = await this.requestPromise<V1APIResourceList>(
+                localVarRequestOptions,
+                'V1APIResourceList',
+            );
+            const apiResourceList = getApiResponse.body;
+            return apiResourceList.resources.find((r) => r.kind === kind);
+        } catch (e) {
+            e.message = `Failed to fetch resource metadata for ${apiVersion}/${kind}: ${e.message}`;
+            throw e;
+        }
+    }
+
+    /**
+     * Standard Kubernetes request wrapped in a Promise.
+     */
+    protected async requestPromise<T extends KubernetesObjectResponseBody = KubernetesObject>(
+        requestOptions: request.Options,
+        tipe: string = 'KubernetesObject',
+    ): Promise<{ body: T; response: http.IncomingMessage }> {
+        let authenticationPromise = Promise.resolve();
+        if (this.authentications.BearerToken.apiKey) {
+            authenticationPromise = authenticationPromise.then(() =>
+                this.authentications.BearerToken.applyToRequest(requestOptions),
+            );
+        }
+        authenticationPromise = authenticationPromise.then(() =>
+            this.authentications.default.applyToRequest(requestOptions),
+        );
+
+        let interceptorPromise = authenticationPromise;
+        for (const interceptor of this.interceptors) {
+            interceptorPromise = interceptorPromise.then(() => interceptor(requestOptions));
+        }
+        await interceptorPromise;
+
+        return new Promise<{ body: T; response: http.IncomingMessage }>((resolve, reject) => {
+            request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    body = ObjectSerializer.deserialize(body, tipe);
+                    if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                        resolve({ response, body });
+                    } else {
+                        reject(new HttpError(response, body, response.statusCode));
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1,0 +1,1819 @@
+import { expect } from 'chai';
+import * as nock from 'nock';
+import { V1APIResource } from './api';
+import { KubeConfig } from './config';
+import { KubernetesObjectApi } from './object';
+import { KubernetesObject } from './types';
+
+describe('KubernetesObject', () => {
+    const testConfigOptions = {
+        clusters: [{ name: 'dc', server: 'https://d.i.y' }],
+        users: [{ name: 'ian', password: 'mackaye' }],
+        contexts: [{ name: 'dischord', cluster: 'dc', user: 'ian' }],
+        currentContext: 'dischord',
+    };
+
+    describe('makeApiClient', () => {
+        it('should create the client', () => {
+            const kc = new KubeConfig();
+            kc.loadFromOptions(testConfigOptions);
+            const c = KubernetesObjectApi.makeApiClient(kc);
+            expect(c).to.be.ok;
+        });
+
+        it('should set the default namespace from context', () => {
+            const kc = new KubeConfig();
+            kc.loadFromOptions({
+                clusters: [{ name: 'dc', server: 'https://d.i.y' }],
+                users: [{ name: 'ian', password: 'mackaye' }],
+                contexts: [{ name: 'dischord', cluster: 'dc', user: 'ian', namespace: 'straight-edge' }],
+                currentContext: 'dischord',
+            });
+            const c = KubernetesObjectApi.makeApiClient(kc);
+            expect(c).to.be.ok;
+            expect((c as any).defaultNamespace).to.equal('straight-edge');
+        });
+    });
+
+    class KubernetesObjectApiTest extends KubernetesObjectApi {
+        public static makeApiClient(): KubernetesObjectApiTest {
+            const kc = new KubeConfig();
+            kc.loadFromOptions(testConfigOptions);
+            return kc.makeApiClient(KubernetesObjectApiTest);
+        }
+        public static appendName(action: any): boolean {
+            return super.appendName(action);
+        }
+        public async specUriPath(spec: KubernetesObject, method: any): Promise<string> {
+            return super.specUriPath(spec, method);
+        }
+        public generateHeaders(
+            optionsHeaders: { [name: string]: string },
+            action: string = 'GET',
+        ): { [name: string]: string } {
+            return super.generateHeaders(optionsHeaders, action);
+        }
+        public async resource(apiVersion: string, kind: string): Promise<V1APIResource | undefined> {
+            return super.resource(apiVersion, kind);
+        }
+    }
+
+    describe('appendName', () => {
+        it('should return append name', () => {
+            ['delete', 'patch', 'read', 'replace'].forEach((a: any) => {
+                expect(KubernetesObjectApiTest.appendName(a)).to.be.true;
+            });
+        });
+
+        it('should return not append name', () => {
+            expect(KubernetesObjectApiTest.appendName('create')).to.be.false;
+        });
+    });
+
+    const resourceBodies = {
+        core: `{
+  "groupVersion": "v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "Binding",
+      "name": "bindings",
+      "namespaced": true
+    },
+    {
+      "kind": "ComponentStatus",
+      "name": "componentstatuses",
+      "namespaced": false
+    },
+    {
+      "kind": "ConfigMap",
+      "name": "configmaps",
+      "namespaced": true
+    },
+    {
+      "kind": "Endpoints",
+      "name": "endpoints",
+      "namespaced": true
+    },
+    {
+      "kind": "Event",
+      "name": "events",
+      "namespaced": true
+    },
+    {
+      "kind": "LimitRange",
+      "name": "limitranges",
+      "namespaced": true
+    },
+    {
+      "kind": "Namespace",
+      "name": "namespaces",
+      "namespaced": false
+    },
+    {
+      "kind": "Namespace",
+      "name": "namespaces/finalize",
+      "namespaced": false
+    },
+    {
+      "kind": "Namespace",
+      "name": "namespaces/status",
+      "namespaced": false
+    },
+    {
+      "kind": "Node",
+      "name": "nodes",
+      "namespaced": false
+    },
+    {
+      "kind": "NodeProxyOptions",
+      "name": "nodes/proxy",
+      "namespaced": false
+    },
+    {
+      "kind": "Node",
+      "name": "nodes/status",
+      "namespaced": false
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "name": "persistentvolumeclaims",
+      "namespaced": true
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "name": "persistentvolumeclaims/status",
+      "namespaced": true
+    },
+    {
+      "kind": "PersistentVolume",
+      "name": "persistentvolumes",
+      "namespaced": false
+    },
+    {
+      "kind": "PersistentVolume",
+      "name": "persistentvolumes/status",
+      "namespaced": false
+    },
+    {
+      "kind": "Pod",
+      "name": "pods",
+      "namespaced": true
+    },
+    {
+      "kind": "PodAttachOptions",
+      "name": "pods/attach",
+      "namespaced": true
+    },
+    {
+      "kind": "Binding",
+      "name": "pods/binding",
+      "namespaced": true
+    },
+    {
+      "group": "policy",
+      "kind": "Eviction",
+      "name": "pods/eviction",
+      "namespaced": true,
+      "version": "v1beta1"
+    },
+    {
+      "kind": "PodExecOptions",
+      "name": "pods/exec",
+      "namespaced": true
+    },
+    {
+      "kind": "Pod",
+      "name": "pods/log",
+      "namespaced": true
+    },
+    {
+      "kind": "PodPortForwardOptions",
+      "name": "pods/portforward",
+      "namespaced": true
+    },
+    {
+      "kind": "PodProxyOptions",
+      "name": "pods/proxy",
+      "namespaced": true
+    },
+    {
+      "kind": "Pod",
+      "name": "pods/status",
+      "namespaced": true
+    },
+    {
+      "kind": "PodTemplate",
+      "name": "podtemplates",
+      "namespaced": true
+    },
+    {
+      "kind": "ReplicationController",
+      "name": "replicationcontrollers",
+      "namespaced": true
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "replicationcontrollers/scale",
+      "namespaced": true,
+      "version": "v1"
+    },
+    {
+      "kind": "ReplicationController",
+      "name": "replicationcontrollers/status",
+      "namespaced": true
+    },
+    {
+      "kind": "ResourceQuota",
+      "name": "resourcequotas",
+      "namespaced": true
+    },
+    {
+      "kind": "ResourceQuota",
+      "name": "resourcequotas/status",
+      "namespaced": true
+    },
+    {
+      "kind": "Secret",
+      "name": "secrets",
+      "namespaced": true
+    },
+    {
+      "kind": "ServiceAccount",
+      "name": "serviceaccounts",
+      "namespaced": true
+    },
+    {
+      "kind": "Service",
+      "name": "services",
+      "namespaced": true
+    },
+    {
+      "kind": "ServiceProxyOptions",
+      "name": "services/proxy",
+      "namespaced": true
+    },
+    {
+      "kind": "Service",
+      "name": "services/status",
+      "namespaced": true
+    }
+  ]
+}`,
+
+        apps: `{
+  "apiVersion": "v1",
+  "groupVersion": "apps/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "ControllerRevision",
+      "name": "controllerrevisions",
+      "namespaced": true
+    },
+    {
+      "kind": "DaemonSet",
+      "name": "daemonsets",
+      "namespaced": true
+    },
+    {
+      "kind": "DaemonSet",
+      "name": "daemonsets/status",
+      "namespaced": true
+    },
+    {
+      "kind": "Deployment",
+      "name": "deployments",
+      "namespaced": true
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "deployments/scale",
+      "namespaced": true,
+      "version": "v1"
+    },
+    {
+      "kind": "Deployment",
+      "name": "deployments/status",
+      "namespaced": true
+    },
+    {
+      "kind": "ReplicaSet",
+      "name": "replicasets",
+      "namespaced": true
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "replicasets/scale",
+      "namespaced": true,
+      "version": "v1"
+    },
+    {
+      "kind": "ReplicaSet",
+      "name": "replicasets/status",
+      "namespaced": true
+    },
+    {
+      "kind": "StatefulSet",
+      "name": "statefulsets",
+      "namespaced": true
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "statefulsets/scale",
+      "namespaced": true,
+      "version": "v1"
+    },
+    {
+      "kind": "StatefulSet",
+      "name": "statefulsets/status",
+      "namespaced": true
+    }
+  ]
+}`,
+        extensions: `{
+  "groupVersion": "extensions/v1beta1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "DaemonSet",
+      "name": "daemonsets",
+      "namespaced": true
+    },
+    {
+      "kind": "DaemonSet",
+      "name": "daemonsets/status",
+      "namespaced": true
+    },
+    {
+      "kind": "Deployment",
+      "name": "deployments",
+      "namespaced": true
+    },
+    {
+      "kind": "DeploymentRollback",
+      "name": "deployments/rollback",
+      "namespaced": true
+    },
+    {
+      "group": "extensions",
+      "kind": "Scale",
+      "name": "deployments/scale",
+      "namespaced": true,
+      "version": "v1beta1"
+    },
+    {
+      "kind": "Deployment",
+      "name": "deployments/status",
+      "namespaced": true
+    },
+    {
+      "kind": "Ingress",
+      "name": "ingresses",
+      "namespaced": true
+    },
+    {
+      "kind": "Ingress",
+      "name": "ingresses/status",
+      "namespaced": true
+    },
+    {
+      "kind": "NetworkPolicy",
+      "name": "networkpolicies",
+      "namespaced": true
+    },
+    {
+      "kind": "PodSecurityPolicy",
+      "name": "podsecuritypolicies",
+      "namespaced": false
+    },
+    {
+      "kind": "ReplicaSet",
+      "name": "replicasets",
+      "namespaced": true
+    },
+    {
+      "group": "extensions",
+      "kind": "Scale",
+      "name": "replicasets/scale",
+      "namespaced": true,
+      "version": "v1beta1"
+    },
+    {
+      "kind": "ReplicaSet",
+      "name": "replicasets/status",
+      "namespaced": true
+    },
+    {
+      "kind": "ReplicationControllerDummy",
+      "name": "replicationcontrollers",
+      "namespaced": true
+    },
+    {
+      "kind": "Scale",
+      "name": "replicationcontrollers/scale",
+      "namespaced": true
+    }
+  ]
+}`,
+        networking: `{
+  "apiVersion": "v1",
+  "groupVersion": "networking.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "NetworkPolicy",
+      "name": "networkpolicies",
+      "namespaced": true
+    }
+  ]
+}`,
+        rbac: `{
+  "apiVersion": "v1",
+  "groupVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "ClusterRoleBinding",
+      "name": "clusterrolebindings",
+      "namespaced": false
+    },
+    {
+      "kind": "ClusterRole",
+      "name": "clusterroles",
+      "namespaced": false
+    },
+    {
+      "kind": "RoleBinding",
+      "name": "rolebindings",
+      "namespaced": true
+    },
+    {
+      "kind": "Role",
+      "name": "roles",
+      "namespaced": true
+    }
+  ]
+}`,
+        storage: `{
+  "apiVersion": "v1",
+  "groupVersion": "storage.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "StorageClass",
+      "name": "storageclasses",
+      "namespaced": false
+    },
+    {
+      "kind": "VolumeAttachment",
+      "name": "volumeattachments",
+      "namespaced": false
+    },
+    {
+      "kind": "VolumeAttachment",
+      "name": "volumeattachments/status",
+      "namespaced": false
+    }
+  ]
+}`,
+    };
+
+    describe('specUriPath', () => {
+        let client: KubernetesObjectApiTest;
+        before(function(this: Mocha.Context): void {
+            client = KubernetesObjectApiTest.makeApiClient();
+        });
+
+        it('should return a namespaced path', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    name: 'repeater',
+                    namespace: 'fugazi',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            const r = await client.specUriPath(o, 'patch');
+            expect(r).to.equal('https://d.i.y/api/v1/namespaces/fugazi/services/repeater');
+            scope.done();
+        });
+
+        it('should default to apiVersion v1', async () => {
+            const o = {
+                kind: 'ServiceAccount',
+                metadata: {
+                    name: 'repeater',
+                    namespace: 'fugazi',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            const r = await client.specUriPath(o, 'patch');
+            expect(r).to.equal('https://d.i.y/api/v1/namespaces/fugazi/serviceaccounts/repeater');
+            scope.done();
+        });
+
+        it('should default to default namespace', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Pod',
+                metadata: {
+                    name: 'repeater',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            const r = await client.specUriPath(o, 'patch');
+            expect(r).to.equal('https://d.i.y/api/v1/namespaces/default/pods/repeater');
+            scope.done();
+        });
+
+        it('should return a non-namespaced path', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Namespace',
+                metadata: {
+                    name: 'repeater',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            const r = await client.specUriPath(o, 'delete');
+            expect(r).to.equal('https://d.i.y/api/v1/namespaces/repeater');
+            scope.done();
+        });
+
+        it('should return a namespaced path without name', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    namespace: 'fugazi',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            const r = await client.specUriPath(o, 'create');
+            expect(r).to.equal('https://d.i.y/api/v1/namespaces/fugazi/services');
+            scope.done();
+        });
+
+        it('should return a non-namespaced path without name', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Namespace',
+                metadata: {
+                    name: 'repeater',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            const r = await client.specUriPath(o, 'create');
+            expect(r).to.equal('https://d.i.y/api/v1/namespaces');
+            scope.done();
+        });
+
+        it('should return a namespaced path for non-core resource', async () => {
+            const o = {
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: {
+                    name: 'repeater',
+                    namespace: 'fugazi',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/apis/apps/v1')
+                .reply(200, resourceBodies.apps);
+            const r = await client.specUriPath(o, 'read');
+            expect(r).to.equal('https://d.i.y/apis/apps/v1/namespaces/fugazi/deployments/repeater');
+            scope.done();
+        });
+
+        it('should return a non-namespaced path for non-core resource', async () => {
+            const o = {
+                apiVersion: 'rbac.authorization.k8s.io/v1',
+                kind: 'ClusterRole',
+                metadata: {
+                    name: 'repeater',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/apis/rbac.authorization.k8s.io/v1')
+                .reply(200, resourceBodies.rbac);
+            const r = await client.specUriPath(o, 'read');
+            expect(r).to.equal('https://d.i.y/apis/rbac.authorization.k8s.io/v1/clusterroles/repeater');
+            scope.done();
+        });
+
+        it('should handle a variety of resources', async () => {
+            const a = [
+                {
+                    apiVersion: 'v1',
+                    kind: 'Service',
+                    ns: true,
+                    p: '/api/v1',
+                    b: resourceBodies.core,
+                    e: 'https://d.i.y/api/v1/namespaces/fugazi/services/repeater',
+                },
+                {
+                    apiVersion: 'v1',
+                    kind: 'ServiceAccount',
+                    ns: true,
+                    p: '/api/v1',
+                    b: resourceBodies.core,
+                    e: 'https://d.i.y/api/v1/namespaces/fugazi/serviceaccounts/repeater',
+                },
+                {
+                    apiVersion: 'rbac.authorization.k8s.io/v1',
+                    kind: 'Role',
+                    ns: true,
+                    p: '/apis/rbac.authorization.k8s.io/v1',
+                    b: resourceBodies.rbac,
+                    e: 'https://d.i.y/apis/rbac.authorization.k8s.io/v1/namespaces/fugazi/roles/repeater',
+                },
+                {
+                    apiVersion: 'rbac.authorization.k8s.io/v1',
+                    kind: 'ClusterRole',
+                    ns: false,
+                    p: '/apis/rbac.authorization.k8s.io/v1',
+                    b: resourceBodies.rbac,
+                    e: 'https://d.i.y/apis/rbac.authorization.k8s.io/v1/clusterroles/repeater',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'NetworkPolicy',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/networkpolicies/repeater',
+                },
+                {
+                    apiVersion: 'networking.k8s.io/v1',
+                    kind: 'NetworkPolicy',
+                    ns: true,
+                    p: '/apis/networking.k8s.io/v1',
+                    b: resourceBodies.networking,
+                    e: 'https://d.i.y/apis/networking.k8s.io/v1/namespaces/fugazi/networkpolicies/repeater',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'Ingress',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/ingresses/repeater',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'DaemonSet',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/daemonsets/repeater',
+                },
+                {
+                    apiVersion: 'apps/v1',
+                    kind: 'DaemonSet',
+                    ns: true,
+                    p: '/apis/apps/v1',
+                    b: resourceBodies.apps,
+                    e: 'https://d.i.y/apis/apps/v1/namespaces/fugazi/daemonsets/repeater',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'Deployment',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/deployments/repeater',
+                },
+                {
+                    apiVersion: 'apps/v1',
+                    kind: 'Deployment',
+                    ns: true,
+                    p: '/apis/apps/v1',
+                    b: resourceBodies.apps,
+                    e: 'https://d.i.y/apis/apps/v1/namespaces/fugazi/deployments/repeater',
+                },
+                {
+                    apiVersion: 'storage.k8s.io/v1',
+                    kind: 'StorageClass',
+                    ns: false,
+                    p: '/apis/storage.k8s.io/v1',
+                    b: resourceBodies.storage,
+                    e: 'https://d.i.y/apis/storage.k8s.io/v1/storageclasses/repeater',
+                },
+            ];
+            for (const k of a) {
+                const o: KubernetesObject = {
+                    apiVersion: k.apiVersion,
+                    kind: k.kind,
+                    metadata: {
+                        name: 'repeater',
+                    },
+                };
+                if (k.ns) {
+                    o.metadata = o.metadata || {};
+                    o.metadata.namespace = 'fugazi';
+                }
+                const scope = nock('https://d.i.y')
+                    .get(k.p)
+                    .reply(200, k.b);
+                const r = await client.specUriPath(o, 'patch');
+                expect(r).to.equal(k.e);
+                scope.done();
+            }
+        });
+
+        it('should handle a variety of resources without names', async () => {
+            const a = [
+                {
+                    apiVersion: 'v1',
+                    kind: 'Service',
+                    ns: true,
+                    p: '/api/v1',
+                    b: resourceBodies.core,
+                    e: 'https://d.i.y/api/v1/namespaces/fugazi/services',
+                },
+                {
+                    apiVersion: 'v1',
+                    kind: 'ServiceAccount',
+                    ns: true,
+                    p: '/api/v1',
+                    b: resourceBodies.core,
+                    e: 'https://d.i.y/api/v1/namespaces/fugazi/serviceaccounts',
+                },
+                {
+                    apiVersion: 'rbac.authorization.k8s.io/v1',
+                    kind: 'Role',
+                    ns: true,
+                    p: '/apis/rbac.authorization.k8s.io/v1',
+                    b: resourceBodies.rbac,
+                    e: 'https://d.i.y/apis/rbac.authorization.k8s.io/v1/namespaces/fugazi/roles',
+                },
+                {
+                    apiVersion: 'rbac.authorization.k8s.io/v1',
+                    kind: 'ClusterRole',
+                    ns: false,
+                    p: '/apis/rbac.authorization.k8s.io/v1',
+                    b: resourceBodies.rbac,
+                    e: 'https://d.i.y/apis/rbac.authorization.k8s.io/v1/clusterroles',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'NetworkPolicy',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/networkpolicies',
+                },
+                {
+                    apiVersion: 'networking.k8s.io/v1',
+                    kind: 'NetworkPolicy',
+                    ns: true,
+                    p: '/apis/networking.k8s.io/v1',
+                    b: resourceBodies.networking,
+                    e: 'https://d.i.y/apis/networking.k8s.io/v1/namespaces/fugazi/networkpolicies',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'Ingress',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/ingresses',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'DaemonSet',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/daemonsets',
+                },
+                {
+                    apiVersion: 'apps/v1',
+                    kind: 'DaemonSet',
+                    ns: true,
+                    p: '/apis/apps/v1',
+                    b: resourceBodies.apps,
+                    e: 'https://d.i.y/apis/apps/v1/namespaces/fugazi/daemonsets',
+                },
+                {
+                    apiVersion: 'extensions/v1beta1',
+                    kind: 'Deployment',
+                    ns: true,
+                    p: '/apis/extensions/v1beta1',
+                    b: resourceBodies.extensions,
+                    e: 'https://d.i.y/apis/extensions/v1beta1/namespaces/fugazi/deployments',
+                },
+                {
+                    apiVersion: 'apps/v1',
+                    kind: 'Deployment',
+                    ns: true,
+                    p: '/apis/apps/v1',
+                    b: resourceBodies.apps,
+                    e: 'https://d.i.y/apis/apps/v1/namespaces/fugazi/deployments',
+                },
+                {
+                    apiVersion: 'storage.k8s.io/v1',
+                    kind: 'StorageClass',
+                    ns: false,
+                    p: '/apis/storage.k8s.io/v1',
+                    b: resourceBodies.storage,
+                    e: 'https://d.i.y/apis/storage.k8s.io/v1/storageclasses',
+                },
+            ];
+            for (const k of a) {
+                const o: KubernetesObject = {
+                    apiVersion: k.apiVersion,
+                    kind: k.kind,
+                };
+                if (k.ns) {
+                    o.metadata = { namespace: 'fugazi' };
+                }
+                const scope = nock('https://d.i.y')
+                    .get(k.p)
+                    .reply(200, k.b);
+                const r = await client.specUriPath(o, 'create');
+                expect(r).to.equal(k.e);
+                scope.done();
+            }
+        });
+
+        it('should throw an error if kind missing', async () => {
+            const o = {
+                apiVersion: 'v1',
+                metadata: {
+                    name: 'repeater',
+                    namespace: 'fugazi',
+                },
+            };
+            let thrown = false;
+            try {
+                await client.specUriPath(o, 'create');
+                expect.fail('should have thrown error');
+            } catch (e) {
+                thrown = true;
+                expect(e.message).to.equal('Required spec property kind is not set');
+            }
+            expect(thrown).to.be.true;
+        });
+
+        it('should throw an error if name required and missing', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    namespace: 'fugazi',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            let thrown = false;
+            try {
+                await client.specUriPath(o, 'read');
+                expect.fail('should have thrown error');
+            } catch (e) {
+                thrown = true;
+                expect(e.message).to.equal('Required spec property name is not set');
+            }
+            expect(thrown).to.be.true;
+            scope.done();
+        });
+
+        it('should throw an error if resource is not valid', async () => {
+            const o = {
+                apiVersion: 'v1',
+                kind: 'Ingress',
+                metadata: {
+                    name: 'repeater',
+                    namespace: 'fugazi',
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            let thrown = false;
+            try {
+                await client.specUriPath(o, 'create');
+                expect.fail('should have thrown error');
+            } catch (e) {
+                thrown = true;
+                expect(e.message).to.equal('Unrecognized API version and kind: v1 Ingress');
+            }
+            expect(thrown).to.be.true;
+            scope.done();
+        });
+    });
+
+    describe('generateHeaders', () => {
+        let client: KubernetesObjectApiTest;
+        before(function(this: Mocha.Context): void {
+            client = KubernetesObjectApiTest.makeApiClient();
+        });
+
+        it('should return default headers', () => {
+            const h = client.generateHeaders({});
+            expect(h.accept).to.equal('application/json');
+        });
+
+        it('should return patch headers', () => {
+            const h = client.generateHeaders({}, 'PATCH');
+            expect(h.accept).to.equal('application/json');
+            expect(h['content-type']).to.equal('application/strategic-merge-patch+json');
+        });
+
+        it('should allow overrides', () => {
+            const h = client.generateHeaders(
+                {
+                    accept: 'application/vnd.kubernetes.protobuf',
+                    'content-type': 'application/merge-patch+json',
+                },
+                'PATCH',
+            );
+            expect(h.accept).to.equal('application/vnd.kubernetes.protobuf');
+            expect(h['content-type']).to.equal('application/merge-patch+json');
+        });
+
+        it('should retain provided headers', () => {
+            const h = client.generateHeaders({
+                burden: 'of Proof',
+                simple: 'Matters',
+            });
+            expect(h.accept).to.equal('application/json');
+            expect(h.burden).to.equal('of Proof');
+            expect(h.simple).to.equal('Matters');
+        });
+    });
+
+    describe('resource', () => {
+        let client: KubernetesObjectApiTest;
+        before(function(this: Mocha.Context): void {
+            client = KubernetesObjectApiTest.makeApiClient();
+        });
+
+        it('should throw an error if apiVersion not set', async () => {
+            for (const a of [null, undefined]) {
+                let thrown = false;
+                try {
+                    await client.resource((a as unknown) as string, 'Service');
+                } catch (e) {
+                    thrown = true;
+                    expect(e.message).to.equal(
+                        'Required parameter apiVersion was null or undefined when calling resource',
+                    );
+                }
+                expect(thrown).to.be.true;
+            }
+        });
+
+        it('should throw an error if kind not set', async () => {
+            for (const a of [null, undefined]) {
+                let thrown = false;
+                try {
+                    await client.resource('v1', (a as unknown) as string);
+                } catch (e) {
+                    thrown = true;
+                    expect(e.message).to.equal(
+                        'Required parameter kind was null or undefined when calling resource',
+                    );
+                }
+                expect(thrown).to.be.true;
+            }
+        });
+
+        it('should use an interceptor', async () => {
+            const c: any = KubernetesObjectApiTest.makeApiClient();
+            let intercepted = false;
+            if (c.interceptors) {
+                c.interceptors.push(async () => {
+                    intercepted = true;
+                });
+            } else {
+                c.interceptors = [
+                    async () => {
+                        intercepted = true;
+                    },
+                ];
+            }
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core);
+            await c.resource('v1', 'Service');
+            expect(intercepted).to.be.true;
+            scope.done();
+        });
+    });
+
+    describe('verbs', () => {
+        let client: KubernetesObjectApi;
+        before(() => {
+            const kc = new KubeConfig();
+            kc.loadFromOptions(testConfigOptions);
+            client = KubernetesObjectApi.makeApiClient(kc);
+        });
+
+        it('should modify resources with defaults', async () => {
+            const s = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    name: 'k8s-js-client-test',
+                    namespace: 'default',
+                },
+                spec: {
+                    ports: [
+                        {
+                            port: 80,
+                            protocol: 'TCP',
+                            targetPort: 80,
+                        },
+                    ],
+                    selector: {
+                        app: 'sleep',
+                    },
+                },
+            };
+            const methods = [
+                {
+                    m: client.create,
+                    v: 'POST',
+                    p: '/api/v1/namespaces/default/services',
+                    c: 201,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.patch,
+                    v: 'PATCH',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.read,
+                    v: 'GET',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.delete,
+                    v: 'DELETE',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "apiVersion": "v1",
+  "details": {
+    "kind": "services",
+    "name": "k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a"
+  },
+  "kind": "Status",
+  "metadata": {},
+  "status": "Success"
+}`,
+                },
+            ];
+            for (const m of methods) {
+                const scope = nock('https://d.i.y')
+                    .get('/api/v1')
+                    .reply(200, resourceBodies.core)
+                    .intercept(m.p, m.v, m.v === 'DELETE' || m.v === 'GET' ? undefined : s)
+                    .reply(m.c, m.b);
+                await m.m.call(client, s);
+                scope.done();
+            }
+        });
+
+        it('should modify resources with pretty set', async () => {
+            const s = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    name: 'k8s-js-client-test',
+                    namespace: 'default',
+                },
+                spec: {
+                    ports: [
+                        {
+                            port: 80,
+                            protocol: 'TCP',
+                            targetPort: 80,
+                        },
+                    ],
+                    selector: {
+                        app: 'sleep',
+                    },
+                },
+            };
+            const methods = [
+                {
+                    m: client.create,
+                    v: 'POST',
+                    p: '/api/v1/namespaces/default/services',
+                    c: 201,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.patch,
+                    v: 'PATCH',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.read,
+                    v: 'GET',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.delete,
+                    v: 'DELETE',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "apiVersion": "v1",
+  "details": {
+    "kind": "services",
+    "name": "k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a"
+  },
+  "kind": "Status",
+  "metadata": {},
+  "status": "Success"
+}`,
+                },
+            ];
+            for (const p of ['true', 'false']) {
+                for (const m of methods) {
+                    const scope = nock('https://d.i.y')
+                        .get('/api/v1')
+                        .reply(200, resourceBodies.core)
+                        .intercept(
+                            `${m.p}?pretty=${p}`,
+                            m.v,
+                            m.v === 'DELETE' || m.v === 'GET' ? undefined : s,
+                        )
+                        .reply(m.c, m.b);
+                    await m.m.call(client, s, p);
+                    scope.done();
+                }
+            }
+        });
+
+        it('should set dryRun', async () => {
+            const s = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    name: 'k8s-js-client-test',
+                    namespace: 'default',
+                },
+                spec: {
+                    ports: [
+                        {
+                            port: 80,
+                            protocol: 'TCP',
+                            targetPort: 80,
+                        },
+                    ],
+                    selector: {
+                        app: 'sleep',
+                    },
+                },
+            };
+            const methods = [
+                {
+                    m: client.create,
+                    v: 'POST',
+                    p: '/api/v1/namespaces/default/services',
+                    c: 201,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.patch,
+                    v: 'PATCH',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a",
+    "resourceVersion": "32373",
+    "creationTimestamp": "2020-05-11T17:34:25Z"
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.97.191.144",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                },
+                {
+                    m: client.delete,
+                    v: 'DELETE',
+                    p: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                    c: 200,
+                    b: `{
+  "apiVersion": "v1",
+  "details": {
+    "kind": "services",
+    "name": "k8s-js-client-test",
+    "uid": "6a43eddc-26bf-424e-ab30-cde3041a706a"
+  },
+  "kind": "Status",
+  "metadata": {},
+  "status": "Success"
+}`,
+                },
+            ];
+            for (const m of methods) {
+                const scope = nock('https://d.i.y')
+                    .get('/api/v1')
+                    .reply(200, resourceBodies.core)
+                    .intercept(`${m.p}?dryRun=All`, m.v, m.v === 'DELETE' || m.v === 'GET' ? undefined : s)
+                    .reply(m.c, m.b);
+                await m.m.call(client, s, undefined, 'All');
+                scope.done();
+            }
+        });
+
+        it('should replace a resource', async () => {
+            const s = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    annotations: {
+                        owner: 'test',
+                    },
+                    name: 'k8s-js-client-test',
+                    namespace: 'default',
+                },
+                spec: {
+                    ports: [
+                        {
+                            port: 80,
+                            protocol: 'TCP',
+                            targetPort: 80,
+                        },
+                    ],
+                    selector: {
+                        app: 'sleep',
+                    },
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core)
+                .post('/api/v1/namespaces/default/services?fieldManager=ManageField', s)
+                .reply(
+                    201,
+                    `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "a4fd7a65-2af5-4ef1-a0bc-cb34a308b821",
+    "resourceVersion": "41183",
+    "creationTimestamp": "2020-05-11T19:35:01Z",
+    "annotations": {
+      "owner": "test"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.106.153.133",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                )
+                .get('/api/v1')
+                .reply(200, resourceBodies.core)
+                .put('/api/v1/namespaces/default/services/k8s-js-client-test?pretty=true', {
+                    kind: 'Service',
+                    apiVersion: 'v1',
+                    metadata: {
+                        name: 'k8s-js-client-test',
+                        namespace: 'default',
+                        selfLink: '/api/v1/namespaces/default/services/k8s-js-client-test',
+                        uid: 'a4fd7a65-2af5-4ef1-a0bc-cb34a308b821',
+                        resourceVersion: '41183',
+                        creationTimestamp: '2020-05-11T19:35:01Z',
+                        annotations: {
+                            owner: 'test',
+                            test: '1',
+                        },
+                    },
+                    spec: {
+                        ports: [
+                            {
+                                protocol: 'TCP',
+                                port: 80,
+                                targetPort: 80,
+                            },
+                        ],
+                        selector: {
+                            app: 'sleep',
+                        },
+                        clusterIP: '10.106.153.133',
+                        type: 'ClusterIP',
+                        sessionAffinity: 'None',
+                    },
+                    status: {
+                        loadBalancer: {},
+                    },
+                })
+                .reply(
+                    200,
+                    `{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "k8s-js-client-test",
+    "namespace": "default",
+    "selfLink": "/api/v1/namespaces/default/services/k8s-js-client-test",
+    "uid": "a4fd7a65-2af5-4ef1-a0bc-cb34a308b821",
+    "resourceVersion": "41185",
+    "creationTimestamp": "2020-05-11T19:35:01Z",
+    "annotations": {
+      "owner": "test",
+      "test": "1"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80
+      }
+    ],
+    "selector": {
+      "app": "sleep"
+    },
+    "clusterIP": "10.106.153.133",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`,
+                )
+                .get('/api/v1')
+                .reply(200, resourceBodies.core)
+                .delete(
+                    '/api/v1/namespaces/default/services/k8s-js-client-test?gracePeriodSeconds=7&propagationPolicy=Foreground',
+                )
+                .reply(
+                    200,
+                    `{
+  "apiVersion": "v1",
+  "details": {
+    "kind": "services",
+    "name": "k8s-js-client-test",
+    "uid": "a4fd7a65-2af5-4ef1-a0bc-cb34a308b821"
+  },
+  "kind": "Status",
+  "metadata": {},
+  "status": "Success"
+}`,
+                );
+            const cr: any = await client.create(s, undefined, undefined, 'ManageField');
+            const rs: any = cr.body;
+            rs.metadata.annotations.test = '1';
+            const rr: any = await client.replace(rs, 'true');
+            expect(rr.body.metadata.annotations.test).to.equal('1');
+            expect(parseInt(rr.body.metadata.resourceVersion, 10)).to.be.greaterThan(
+                parseInt(cr.body.metadata.resourceVersion, 10),
+            );
+            await client.delete(s, undefined, undefined, 7, undefined, 'Foreground');
+            scope.done();
+        });
+    });
+
+    describe('errors', () => {
+        let client: KubernetesObjectApi;
+        before(() => {
+            const kc = new KubeConfig();
+            kc.loadFromOptions(testConfigOptions);
+            client = KubernetesObjectApi.makeApiClient(kc);
+        });
+
+        it('should throw error if no spec', async () => {
+            const methods = [client.create, client.patch, client.read, client.replace, client.delete];
+            for (const s of [null, undefined]) {
+                for (const m of methods) {
+                    let thrown = false;
+                    try {
+                        await m.call(client, s);
+                        expect.fail('should have thrown an error');
+                    } catch (e) {
+                        thrown = true;
+                        expect(e.message).to.contain(
+                            'Required parameter spec was null or undefined when calling ',
+                        );
+                    }
+                    expect(thrown).to.be.true;
+                }
+            }
+        });
+
+        it('should throw an error if request throws an error', async () => {
+            const s = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    name: 'valid-name',
+                    namespace: 'default',
+                },
+                spec: {
+                    ports: [
+                        {
+                            port: 80,
+                            protocol: 'TCP',
+                            targetPort: 80,
+                        },
+                    ],
+                    selector: {
+                        app: 'sleep',
+                    },
+                },
+            };
+            nock('https://d.i.y');
+            let thrown = false;
+            try {
+                await client.read(s);
+                expect.fail('should have thrown error');
+            } catch (e) {
+                thrown = true;
+                expect(e.message).to.contain('Nock: No match for request');
+            }
+            expect(thrown).to.be.true;
+        });
+
+        it('should throw an error if name not valid', async () => {
+            const s = {
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: {
+                    name: '_not_a_valid_name_',
+                    namespace: 'default',
+                },
+                spec: {
+                    ports: [
+                        {
+                            port: 80,
+                            protocol: 'TCP',
+                            targetPort: 80,
+                        },
+                    ],
+                    selector: {
+                        app: 'sleep',
+                    },
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/api/v1')
+                .reply(200, resourceBodies.core)
+                .post('/api/v1/namespaces/default/services', s)
+                .reply(
+                    422,
+                    `{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "metadata": {},
+  "status": "Failure",
+  "message": "Service \"_not_a_valid_name_\" is invalid: metadata.name: Invalid value: \"_not_a_valid_name_\": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')",
+  "reason": "Invalid",
+  "details": {
+    "name": "_not_a_valid_name_",
+    "kind": "Service",
+    "causes": [
+      {
+        "reason": "FieldValueInvalid",
+        "message": "Invalid value: \"_not_a_valid_name_\": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')",
+        "field": "metadata.name"
+      }
+    ]
+  },
+  "code": 422
+}`,
+                );
+            let thrown = false;
+            try {
+                await client.create(s);
+            } catch (e) {
+                thrown = true;
+                expect(e.statusCode).to.equal(422);
+                expect(e.message).to.equal('HTTP request failed');
+            }
+            expect(thrown).to.be.true;
+            scope.done();
+        });
+
+        it('should throw an error if apiVersion not valid', async () => {
+            const d = {
+                apiVersion: 'applications/v1',
+                kind: 'Deployment',
+                metadata: {
+                    name: 'should-not-be-created',
+                    namespace: 'default',
+                },
+                spec: {
+                    selector: {
+                        matchLabels: {
+                            app: 'sleep',
+                        },
+                    },
+                    template: {
+                        metadata: {
+                            labels: {
+                                app: 'sleep',
+                            },
+                        },
+                        spec: {
+                            containers: [
+                                {
+                                    args: ['60'],
+                                    command: ['sleep'],
+                                    image: 'alpine',
+                                    name: 'sleep',
+                                    ports: [{ containerPort: 80 }],
+                                },
+                            ],
+                        },
+                    },
+                },
+            };
+            const scope = nock('https://d.i.y')
+                .get('/apis/applications/v1')
+                .reply(404, `{}`);
+            let thrown = false;
+            try {
+                await client.create(d);
+            } catch (e) {
+                thrown = true;
+                expect(e.statusCode).to.equal(404);
+                expect(e.message).to.equal(
+                    'Failed to fetch resource metadata for applications/v1/Deployment: HTTP request failed',
+                );
+            }
+            expect(thrown).to.be.true;
+            scope.done();
+        });
+    });
+});


### PR DESCRIPTION
Add generic object API that dynamically determines endpoint based on
the provided spec.  Add KubernetesObjectApi to index exports.  Provide
tests and example usage.

Closes kubernetes-client/javascript#375