### PR TITLE
Make watch path match listFn

### DIFF
--- a/examples/cache-example.js
+++ b/examples/cache-example.js
@@ -5,7 +5,7 @@ kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-const path = '/api/v1/namespaces/default/pods';
+const path = '/api/v1/pods';
 const watch = new k8s.Watch(kc);
 
 const listFn = () => k8sApi.listPodForAllNamespaces()


### PR DESCRIPTION
Right now the listFunction lists pods from all namespaces but the path watches only pods from the default namespace.

The typescript informer example lists the default namespace so I decided to make this example list/watch all namespaces.