### PR TITLE
Add support for NodeJS version 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '12', '10' ]
+        node: [ '14', '12', '10' ]
     name: Node ${{ matrix.node }} validation
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Resolves #519 - Add support for NodeJS version 14 (Active LTS Start: 2020-10-20)

`npm test` and `npm run lint` both complete without issues on version 10, 12 and 14. Tested locally and confirmed with Github Actions.

To reviewers/maintainers: Please let me know if there is some version specific tests or code that I should address.