### PR TITLE
Update cp.ts

### DIFF
--- a/src/cp.ts
+++ b/src/cp.ts
@@ -28,7 +28,7 @@ export class Cp {
     ): Promise<void> {
         const tmpFile = tmp.fileSync();
         const tmpFileName = tmpFile.name;
-        const command = ['tar', 'cf', '-', srcPath];
+        const command = ['tar', 'zcf', '-', srcPath];
         const writerStream = fs.createWriteStream(tmpFileName);
         const errStream = new WritableStreamBuffer();
         this.execInstance.exec(

--- a/src/cp_test.ts
+++ b/src/cp_test.ts
@@ -21,7 +21,7 @@ describe('Cp', () => {
             const container = 'container';
             const srcPath = '/';
             const tgtPath = '/';
-            const cmdArray = ['tar', 'cf', '-', srcPath];
+            const cmdArray = ['tar', 'zcf', '-', srcPath];
             const path = `/api/v1/namespaces/${namespace}/pods/${pod}/exec`;
 
             const query = {


### PR DESCRIPTION
It's faster to copy compressed data, and, in my case, it prevented following error:
"UnhandledPromiseRejectionWarning: Error: TAR_BAD_ARCHIVE: Truncated input (needed 31232 more bytes, only 0 available)"