### PR TITLE
Fix timeout on watch.js requestOptions

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -64,6 +64,8 @@ export class Watch {
             uri: url,
             useQuerystring: true,
             json: true,
+            forever: true,
+            timeout: 0,
         };
         await this.config.applyToRequest(requestOptions);
 


### PR DESCRIPTION
The watching of Kubernetes object stops after 60 seconds - as the default timeout of 60 seconds is used.
It should be set to 0 - so infinite or at least be more configureable.

Using the RequestInterface to configure this is not the best option as in line 70 the request options gets applied to the config but not taken from any passed configuration.

Also the forever flag could be set.