### PR TITLE
Add prepack script to package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "watch": "tsc --watch",
     "test": "nyc mocha",
     "prepare": "npm run build",
+    "prepack": "npm run build",
     "docs": "typedoc src/gen/api"
   },
   "nyc": {


### PR DESCRIPTION
prepack is needed to be compatible with `yarn` when installing from github or local source. See yarn documentation: https://yarnpkg.com/advanced/lifecycle-scripts

prepack is also defined in npm: https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts