### PR TITLE
cache: Fix connection leak.

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,5 +1,6 @@
 import byline = require('byline');
 import request = require('request');
+import { Duplex } from 'stream';
 import { KubeConfig } from './config';
 
 export interface WatchUpdate {
@@ -7,24 +8,49 @@ export interface WatchUpdate {
     object: object;
 }
 
+// We cannot use the type ReadableStream because Request returned by request
+// library is not a true ReadableStream and there is extra abort method.
+export interface RequestResult {
+    pipe(stream: Duplex): void;
+    on(ev: string, cb: (arg: any) => void): void;
+    abort(): void;
+}
+
 export interface Response {
     statusCode: number;
     statusMessage: string;
 }
 
+// The contract is that the provided request library will return a readable
+// stream with abort method.
 export interface RequestInterface {
-    webRequest(
-        opts: request.Options,
-        callback: (err: object | null, response: Response | null, body: object | null) => void,
-    ): any;
+    webRequest(opts: request.OptionsWithUri): RequestResult;
 }
 
 export class DefaultRequest implements RequestInterface {
-    public webRequest(
-        opts: request.Options,
-        callback: (err: object | null, response: Response | null, body: object | null) => void,
-    ): any {
-        return request(opts, callback);
+    // requestImpl can be overriden in case we need to test mocked DefaultRequest
+    private requestImpl: (opts: request.OptionsWithUri) => request.Request;
+
+    constructor(requestImpl?: (opts: request.OptionsWithUri) => request.Request) {
+        this.requestImpl = requestImpl ? requestImpl : request;
+    }
+
+    // Using request lib can be confusing when combining Stream- with Callback-
+    // style API. We avoid the callback and handle HTTP response errors, that
+    // would otherwise require a different error handling, in a transparent way
+    // to the user (see github issue request/request#647 for more info).
+    public webRequest(opts: request.OptionsWithUri): RequestResult {
+        const req = this.requestImpl(opts);
+        // pause the stream until we get a response not to miss any bytes
+        req.pause();
+        req.on('response', (resp) => {
+            if (resp.statusCode === 200) {
+                req.resume();
+            } else {
+                req.emit('error', new Error(resp.statusMessage));
+            }
+        });
+        return req;
     }
 }
 
@@ -42,12 +68,17 @@ export class Watch {
         }
     }
 
+    // Watch the resource and call provided callback with parsed json object
+    // upon event received over the watcher connection.
+    //
+    // "done" callback is called either when connection is closed or when there
+    // is an error. In either case, watcher takes care of properly closing the
+    // underlaying connection so that it doesn't leak any resources.
     public async watch(
         path: string,
         queryParams: any,
         callback: (phase: string, apiObj: any, watchObj?: any) => void,
-        done: () => void,
-        error: (err: any) => void,
+        done: (err: any) => void,
     ): Promise<any> {
         const cluster = this.config.getCurrentCluster();
         if (!cluster) {
@@ -58,19 +89,31 @@ export class Watch {
         queryParams.watch = true;
         const headerParams: any = {};
 
-        const requestOptions: request.Options = {
+        const requestOptions: request.OptionsWithUri = {
             method: 'GET',
             qs: queryParams,
             headers: headerParams,
             uri: url,
             useQuerystring: true,
             json: true,
-            forever: true,
-            timeout: 0,
+            pool: false,
         };
         await this.config.applyToRequest(requestOptions);
 
+        let req;
+        let doneCalled: boolean = false;
+        const doneCallOnce = (err: any) => {
+            if (!doneCalled) {
+                req.abort();
+                doneCalled = true;
+                done(err);
+            }
+        };
+        req = this.requestImpl.webRequest(requestOptions);
         const stream = byline.createStream();
+        req.on('error', doneCallOnce);
+        stream.on('error', doneCallOnce);
+        stream.on('close', () => doneCallOnce(null));
         stream.on('data', (line) => {
             try {
                 const data = JSON.parse(line);
@@ -79,20 +122,7 @@ export class Watch {
                 // ignore parse errors
             }
         });
-        stream.on('error', error);
-        stream.on('close', done);
 
-        const req = this.requestImpl.webRequest(requestOptions, (err, response, body) => {
-            if (err) {
-                error(err);
-                done();
-            } else if (response && response.statusCode !== 200) {
-                error(new Error(response.statusMessage));
-                done();
-            } else {
-                done();
-            }
-        });
         req.pipe(stream);
         return req;
     }


### PR DESCRIPTION
Make sure that done callback of a watcher isn't called more than once and call abort() on request object to close the connection when done.

It reimplements earlier fix done by @brendandburns for the problem of calling watcher done callback more than once (PR #505) and fixes missing abort call on watcher connections (alternative fix is being currently reviewed in PR #575). Also it undos changes done by @jhagestedt on behalf of PR #526, that I don't understand (as I have commented here https://github.com/kubernetes-client/javascript/pull/526#issuecomment-749478677).

Let me know guys what do you think about it or what could be improved. Thanks!
 
The changes have been tested to work on kubeadm cluster running in aws and setup by kubeadm and in azure with managed k8s service (AKS).