### PR TITLE
cache: skip callback upon restart if object did not change

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -197,15 +197,25 @@ export function addOrUpdateObject<T extends KubernetesObject>(
             addCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
         }
     } else {
-        objects[ix] = obj;
-        if (updateCallback) {
-            updateCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
+        if (!isSameVersion(objects[ix], obj)) {
+            objects[ix] = obj;
+            if (updateCallback) {
+                updateCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
+            }
         }
     }
 }
 
 function isSameObject<T extends KubernetesObject>(o1: T, o2: T): boolean {
     return o1.metadata!.name === o2.metadata!.name && o1.metadata!.namespace === o2.metadata!.namespace;
+}
+
+function isSameVersion<T extends KubernetesObject>(o1: T, o2: T): boolean {
+    return (
+        o1.metadata!.resourceVersion !== undefined &&
+        o1.metadata!.resourceVersion !== null &&
+        o1.metadata!.resourceVersion === o2.metadata!.resourceVersion
+    );
 }
 
 function findKubernetesObject<T extends KubernetesObject>(objects: T[], obj: T): number {

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -330,11 +330,13 @@ describe('ListWatchCache', () => {
             {
                 metadata: {
                     name: 'name1',
+                    resourceVersion: '9876',
                 } as V1ObjectMeta,
             } as V1Namespace,
             {
                 metadata: {
                     name: 'name2',
+                    resourceVersion: '8765',
                 } as V1ObjectMeta,
             } as V1Namespace,
         ];
@@ -387,7 +389,7 @@ describe('ListWatchCache', () => {
         doneHandler(null);
         await promise;
         expect(addObjects).to.deep.equal(list);
-        expect(updateObjects).to.deep.equal(list);
+        expect(updateObjects).to.deep.equal([]);
     });
 
     it('should perform work as an informer with initial list and delete after', async () => {
@@ -396,11 +398,13 @@ describe('ListWatchCache', () => {
             {
                 metadata: {
                     name: 'name1',
+                    resourceVersion: '9876',
                 } as V1ObjectMeta,
             } as V1Namespace,
             {
                 metadata: {
                     name: 'name2',
+                    resourceVersion: '8765',
                 } as V1ObjectMeta,
             } as V1Namespace,
         ];
@@ -408,6 +412,7 @@ describe('ListWatchCache', () => {
             {
                 metadata: {
                     name: 'name1',
+                    resourceVersion: '9999',
                 } as V1ObjectMeta,
             } as V1Namespace,
         ];
@@ -467,6 +472,7 @@ describe('ListWatchCache', () => {
             {
                 metadata: {
                     name: 'name2',
+                    resourceVersion: '8765',
                 } as V1ObjectMeta,
             } as V1Namespace,
         ]);


### PR DESCRIPTION
Currently MOD callbacks are called for all objects in the cache when
the watcher is restarted. This commit makes the algorithm smarter
and call MOD callback only if the object has really changed. The decision
is based on "resourceVersion" metadata field in the object.