### PR TITLE
Use npm ci as safer install option for CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,5 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run lint
+      - run: npm audit –audit-level=critical
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,5 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run lint
-      - run: npm audit –audit-level=critical
+      - run: npm audit --audit-level=critical
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       # Pre-check to validate that versions match between package.json
       # and package-lock.json. Needs to run before npm install
       - run: node version-check.js
-      - run: npm install
+      - run: npm ci
       - run: npm test
       - run: npm run lint
 


### PR DESCRIPTION
References https://github.com/kubernetes-client/javascript/pull/605

An attempt to get CI to fail when using a non public registry 