### PR TITLE
Add a unit test to require registry.npm.js as the package registry.

### DIFF
--- a/src/package_test.ts
+++ b/src/package_test.ts
@@ -7,4 +7,21 @@ describe('package', () => {
         const v2 = require('../package-lock.json').version;
         expect(v1).to.equal(v2);
     });
+
+    it('package-lock should only reference npm', () => {
+        const validateDependencies = (deps) => {
+            if (!deps.dependencies) {
+                return;
+            }
+            for (const key in deps.dependencies) {
+                const dep = deps.dependencies[key];
+                const resolved = new URL(dep.resolved);
+                expect(resolved.hostname).to.equal('registry.npmjs.org');
+                expect(resolved.protocol).to.equal('https:');
+                validateDependencies(dep);
+            }
+        };
+        const deps = require('../package-lock.json');
+        validateDependencies(deps);
+    });
 });


### PR DESCRIPTION
Fixes #612 