### PR TITLE
fix: watch request to use keep-alive connections

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -97,6 +97,7 @@ export class Watch {
             useQuerystring: true,
             json: true,
             pool: false,
+            forever: true,
         };
         await this.config.applyToRequest(requestOptions);
 


### PR DESCRIPTION
Re-use connections between watch requests. Based on request documentation (https://github.com/request/request#requestoptions-callback)