### PR TITLE
Added filtering of empty paths in KUBECONFIG

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -284,7 +284,7 @@ export class KubeConfig {
 
     public loadFromDefault(opts?: Partial<ConfigOptions>, contextFromStartingConfig: boolean = false): void {
         if (process.env.KUBECONFIG && process.env.KUBECONFIG.length > 0) {
-            const files = process.env.KUBECONFIG.split(path.delimiter);
+            const files = process.env.KUBECONFIG.split(path.delimiter).filter((filename: string) => filename);
             this.loadFromFile(files[0], opts);
             for (let i = 1; i < files.length; i++) {
                 const kc = new KubeConfig();

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1064,6 +1064,18 @@ describe('KubeConfig', () => {
             const kc = new KubeConfig();
             expect(() => kc.loadFromDefault()).to.throw('Duplicate user: user1');
         });
+
+        it('should ignore extra path delimiters', () => {
+            process.env.KUBECONFIG = path.delimiter + kcFileName + path.delimiter;
+
+            const kc = new KubeConfig();
+            kc.loadFromDefault();
+
+            expect(kc.clusters.length).to.equal(2);
+            expect(kc.users.length).to.equal(3);
+            expect(kc.contexts.length).to.equal(3);
+            expect(kc.getCurrentContext()).to.equal('context2');
+        });
     });
 
     function platformPath(path: string) {


### PR DESCRIPTION
Addresses issues #627 

It filters out empty entries in the parsed file list.