### PR TITLE
fix: remove dependency on net-keepalive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,6 +1014,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       },
@@ -1021,7 +1022,8 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -1209,19 +1211,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
-      }
-    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -1400,19 +1389,6 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "requires": {
-        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "getpass": {
@@ -2409,22 +2385,14 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
     },
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "net-keepalive": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/net-keepalive/-/net-keepalive-2.0.4.tgz",
-      "integrity": "sha512-T85XzamXNCzezArXJfbUk1ScDfhSRZFnKlp+KGiRuS7IPH6ftaUy+WQfW+i0EH3yRc5/kbyXNhSnmmnCQWrxBg==",
-      "requires": {
-        "ffi-napi": "^4.0.1",
-        "ref-napi": "^3.0.0"
-      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -2448,11 +2416,6 @@
         "semver": "^5.5.0"
       }
     },
-    "node-addon-api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
-    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -2470,11 +2433,6 @@
           "dev": true
         }
       }
-    },
-    "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-preload": {
       "version": "0.2.1",
@@ -2978,42 +2936,6 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "ref-napi": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
-      "integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.1"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-        }
-      }
-    },
-    "ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "release-zalgo": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "isomorphic-ws": "^4.0.1",
     "js-yaml": "^3.13.1",
     "jsonpath-plus": "^0.19.0",
-    "net-keepalive": "2.0.4",
     "openid-client": "^4.1.1",
     "request": "^2.88.0",
     "rfc4648": "^1.3.0",

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,5 +1,4 @@
 import byline = require('byline');
-import keepalive = require('net-keepalive');
 import request = require('request');
 import { Duplex } from 'stream';
 import { KubeConfig } from './config';
@@ -115,8 +114,7 @@ export class Watch {
         req.on('error', doneCallOnce);
         req.on('socket', (socket) => {
             socket.setTimeout(30000);
-            socket.setKeepAlive(true);
-            keepalive.setKeepAliveInterval(socket, 30000);
+            socket.setKeepAlive(true, 30000);
         });
         stream.on('error', doneCallOnce);
         stream.on('close', () => doneCallOnce(null));


### PR DESCRIPTION
node's net socket.setKeepAlive has an optional initial delay parameter. By setting this, it will request that the socket sends a TCP keep-alive probe every N milliseconds, removing the need for net-keepalive which is not portable.

https://nodejs.org/api/net.html#net_socket_setkeepalive_enable_initialdelay

fixes #632 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>