### PR TITLE
Loading KubeConfig from wsl

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -304,7 +304,7 @@ export class KubeConfig {
         if (process.platform === 'win32' && shelljs.which('wsl.exe')) {
             // TODO: Handle if someome set $KUBECONFIG in wsl here...
             try {
-                const result = execa.sync('wsl.exe', ['cat', shelljs.homedir() + '/.kube/config']);
+                const result = execa.sync('wsl.exe', ['cat', '~/.kube/config']);
                 if (result.exitCode === 0) {
                     this.loadFromString(result.stdout, opts);
                     return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -302,7 +302,22 @@ export class KubeConfig {
             }
         }
         if (process.platform === 'win32' && shelljs.which('wsl.exe')) {
-            // TODO: Handle if someome set $KUBECONFIG in wsl here...
+            try {
+                const envKubeconfigPathResult = execa.sync('wsl.exe', ['bash', '-ic', 'printenv KUBECONFIG']);
+                if (envKubeconfigPathResult.exitCode === 0 && envKubeconfigPathResult.stdout.length > 0) {
+                    const result = execa.sync('wsl.exe', ['cat', envKubeconfigPathResult.stdout]);
+                    if (result.exitCode === 0) {
+                        this.loadFromString(result.stdout, opts);
+                        return;
+                    }
+                    if (result.exitCode === 0) {
+                        this.loadFromString(result.stdout, opts);
+                        return;
+                    }
+                }
+            } catch (err) {
+                // Falling back to default kubeconfig
+            }
             try {
                 const result = execa.sync('wsl.exe', ['cat', '~/.kube/config']);
                 if (result.exitCode === 0) {


### PR DESCRIPTION
When updating `execa` yesterday I noticed the `TODO` for loading a user's `$KUBECONFIG` when using WSL. Since I'm a WSL user I decided to try and resolve that `TODO`.

There are two commits here that could be different PRs if you prefer. The first commit fixes an issue I found when testing my changes. The existing code did `shelljs.homedir() + '/.kube/config'` to build the path to the default kubeconfig, but `shelljs.homedir()` is not a function and returns an error at runtime. Replacing this with `'~/.kube/config'` did work as expected for me.

The second commit handles checking for a users `$KUBECONFIG` environment variable in WSL. This required running `bash -ic` instead of just `wsl.exe` to actually load the user's environment. But using that did work as expected for me.

These changes were tested with Windows 10 and WSL2 Ubuntu 20.04.