### PR TITLE
Changed Content-Type header on method patchNamespacedDeployment

### DIFF
--- a/src/gen/api/appsV1Api.ts
+++ b/src/gen/api/appsV1Api.ts
@@ -3326,6 +3326,10 @@ export class AppsV1Api {
             .replace('{' + 'namespace' + '}', encodeURIComponent(String(namespace)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
+        
+        //Change Content-Type header because the K8s endpoint needs it
+        localVarHeaderParams["Content-Type"] = 'application/merge-patch+json';
+
         const produces = ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'];
         // give precedence to 'application/json'
         if (produces.indexOf('application/json') >= 0) {


### PR DESCRIPTION
I was trying to update deployments with this method, but it always returned error code 415 - Unsupported Media Type. 
So, to make it work, it was needed  to change the Content-Type header to "application/merge-patch+json".