### PR TITLE
Set current context namespace in loadFromCluster()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -224,7 +224,7 @@ export class KubeConfig {
         const namespaceFile = `${pathPrefix}${Config.SERVICEACCOUNT_NAMESPACE_PATH}`;
         let namespace: string | undefined;
         if (fileExists(namespaceFile)) {
-            namespace = fs.readFileSync(namespaceFile, 'utf8')
+            namespace = fs.readFileSync(namespaceFile, 'utf8');
         }
         this.contexts = [
             {

--- a/src/config.ts
+++ b/src/config.ts
@@ -221,11 +221,17 @@ export class KubeConfig {
                 },
             },
         ];
+        const namespaceFile = `${pathPrefix}${Config.SERVICEACCOUNT_NAMESPACE_PATH}`;
+        let namespace: string | undefined;
+        if (fileExists(namespaceFile)) {
+            namespace = fs.readFileSync(namespaceFile, 'utf8')
+        }
         this.contexts = [
             {
                 cluster: clusterName,
                 name: contextName,
                 user: userName,
+                namespace,
             },
         ];
         this.currentContext = contextName;
@@ -448,6 +454,7 @@ export class Config {
     public static SERVICEACCOUNT_ROOT: string = '/var/run/secrets/kubernetes.io/serviceaccount';
     public static SERVICEACCOUNT_CA_PATH: string = Config.SERVICEACCOUNT_ROOT + '/ca.crt';
     public static SERVICEACCOUNT_TOKEN_PATH: string = Config.SERVICEACCOUNT_ROOT + '/token';
+    public static SERVICEACCOUNT_NAMESPACE_PATH: string = Config.SERVICEACCOUNT_ROOT + '/namespace';
 
     public static fromFile(filename: string): api.CoreV1Api {
         return Config.apiFromFile(filename, api.CoreV1Api);

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1151,10 +1151,12 @@ describe('KubeConfig', () => {
             }
             const token = 'token';
             const cert = 'cert';
+            const namespace = 'myNamespace';
             mockfs({
                 '/var/run/secrets/kubernetes.io/serviceaccount': {
                     'ca.crt': cert,
                     token,
+                    namespace,
                 },
             });
 
@@ -1180,6 +1182,12 @@ describe('KubeConfig', () => {
                 expect(user.authProvider.config.tokenFile).to.equal(
                     '/var/run/secrets/kubernetes.io/serviceaccount/token',
                 );
+            }
+            const contextName = kc.getCurrentContext();
+            const currentContext = kc.getContextObject(contextName);
+            expect(currentContext).to.not.be.null;
+            if (currentContext) {
+                expect(currentContext.namespace).to.equal('myNamespace');
             }
         });
 


### PR DESCRIPTION
I use k8s js client within a pod and current context namespace is not set properly.

I read current from namespace from `/var/run/secrets/kubernetes.io/serviceaccount/namespace`

[Doc: Accessing the API from a Pod](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)

