### PR TITLE
Replace callback with promise in Log

### DIFF
--- a/examples/follow-logs.js
+++ b/examples/follow-logs.js
@@ -13,11 +13,11 @@ logStream.on('data', (chunk) => {
 	process.stdout.write(chunk);
 });
 
-log.log('default', 'pod1', 'container1', logStream, (err) => {console.log(err)}, {follow: true, tailLines: 50, pretty: false, timestamps: false})
+log.log('default', 'pod1', 'container1', logStream, {follow: true, tailLines: 50, pretty: false, timestamps: false})
+.catch(err => {console.log(err)})
 .then(req => {
 	// disconnects after 5 seconds
 	setTimeout(function(){
 		req.abort();
 	}, 5000);
 });
-

--- a/src/log.ts
+++ b/src/log.ts
@@ -56,8 +56,32 @@ export class Log {
         podName: string,
         containerName: string,
         stream: Writable,
-        options: LogOptions = {},
+        options?: LogOptions,
+    ): Promise<request.Request>;
+    /** @deprecated done callback is deprecated */
+    public async log(
+        namespace: string,
+        podName: string,
+        containerName: string,
+        stream: Writable,
+        done: (err: any) => void,
+        options?: LogOptions,
+    ): Promise<request.Request>;
+    public async log(
+        namespace: string,
+        podName: string,
+        containerName: string,
+        stream: Writable,
+        doneOrOptions?: ((err: any) => void) | LogOptions,
+        options?: LogOptions,
     ): Promise<request.Request> {
+        let done: (err: any) => void = () => undefined;
+        if (typeof doneOrOptions === 'function') {
+            done = doneOrOptions;
+        } else {
+            options = doneOrOptions;
+        }
+
         const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log`;
 
         const cluster = this.config.getCurrentCluster();
@@ -80,9 +104,13 @@ export class Log {
             const req = request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
+                    done(error);
                 } else if (response.statusCode !== 200) {
-                    body = ObjectSerializer.deserialize(JSON.parse(body), 'V1Status');
-                    reject(new HttpError(response, body, response.statusCode));
+                    const deserializedBody = ObjectSerializer.deserialize(JSON.parse(body), 'V1Status');
+                    reject(new HttpError(response, deserializedBody, response.statusCode));
+                    done(body);
+                } else {
+                    done(null);
                 }
             }).on('response', (response) => {
                 if (response.statusCode === 200) {

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,7 @@
-import request = require('request');
+import * as request from 'request';
 import { Writable } from 'stream';
-
 import { KubeConfig } from './config';
+import { HttpError, ObjectSerializer } from './gen/api';
 
 export interface LogOptions {
     /**
@@ -56,7 +56,6 @@ export class Log {
         podName: string,
         containerName: string,
         stream: Writable,
-        done: (err: any) => void,
         options: LogOptions = {},
     ): Promise<request.Request> {
         const path = `/api/v1/namespaces/${namespace}/pods/${podName}/log`;
@@ -77,20 +76,20 @@ export class Log {
         };
         await this.config.applyToRequest(requestOptions);
 
-        const req = request(requestOptions, (error, response, body) => {
-            if (error) {
-                done(error);
-            } else if (response && response.statusCode !== 200) {
-                done(body);
-            } else {
-                done(null);
-            }
-        }).on('response', (response) => {
-            if (response.statusCode === 200) {
-                req.pipe(stream);
-            }
+        return new Promise((resolve, reject) => {
+            const req = request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else if (response.statusCode !== 200) {
+                    body = ObjectSerializer.deserialize(JSON.parse(body), 'V1Status');
+                    reject(new HttpError(response, body, response.statusCode));
+                }
+            }).on('response', (response) => {
+                if (response.statusCode === 200) {
+                    req.pipe(stream);
+                    resolve(req);
+                }
+            });
         });
-
-        return req;
     }
 }


### PR DESCRIPTION
This replaces the done callback in the `Log.log` function with a promise, which is awaited as part of the log function. This ensures that when the promise of the log function resolves a response **was** received (success or error) from kubernetes. If the response is a 200, the body of the response is streamed into the provided stream. Else the promise is rejected with an error or the complete parsed status response as `HttpError`.

This is a breaking change as the `done` callback was removed from the function. Also the behavior of the returned Promise changed. Before, the Promise was resolved when the request was send, now it resolved after the response headers are received or an error occurred.

I also updated the `follow-logs.js` example.