### PR TITLE
Change 'port' in v1HTTPGetAction to reflect proper type options

### DIFF
--- a/src/gen/model/v1HTTPGetAction.ts
+++ b/src/gen/model/v1HTTPGetAction.ts
@@ -32,7 +32,7 @@ export class V1HTTPGetAction {
     /**
     * Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
     */
-    'port': object;
+    'port': string | number;
     /**
     * Scheme to use for connecting to the host. Defaults to HTTP.
     */


### PR DESCRIPTION
`Object` is not the correct type, and makes typescript usage annoying since you need to do something like: `port: 'http' as Object` to allow it to work