### PR TITLE
Attempt to start list watch from last resourceVersion

### DIFF
--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -197,7 +197,9 @@ describe('ListWatchCache', () => {
             } as V1ObjectMeta,
         } as V1Namespace);
 
-        await doneHandler(null);
+        const error = new Error('Gone') as Error & { statusCode: number | undefined };
+        error.statusCode = 410;
+        await doneHandler(error);
         expect(cache.list().length, 'all namespace list').to.equal(1);
         expect(cache.list('default').length, 'default namespace list').to.equal(1);
         expect(cache.list('other'), 'other namespace list').to.be.undefined;
@@ -570,7 +572,9 @@ describe('ListWatchCache', () => {
             });
         });
         listObj.items = list2;
-        doneHandler(null);
+        const error = new Error('Gone') as Error & { statusCode: number | undefined };
+        error.statusCode = 410;
+        await doneHandler(error);
         await promise;
         expect(addObjects).to.deep.equal(list);
         expect(updateObjects).to.deep.equal(list2);
@@ -1172,7 +1176,8 @@ describe('ListWatchCache', () => {
 
         const [, , , doneHandler] = mock.capture(fakeWatch.watch).last();
 
-        const error = new Error('Gone');
+        const error = new Error('Gone') as Error & { statusCode: number | undefined };
+        error.statusCode = 410;
         await doneHandler(error);
 
         mock.verify(

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -47,7 +47,9 @@ export class DefaultRequest implements RequestInterface {
             if (resp.statusCode === 200) {
                 req.resume();
             } else {
-                req.emit('error', new Error(resp.statusMessage));
+                const error = new Error(resp.statusMessage) as Error & { statusCode: number | undefined };
+                error.statusCode = resp.statusCode;
+                req.emit('error', error);
             }
         });
         return req;


### PR DESCRIPTION
This change should avoid unnecessary calls to the listFn that populates
the ListWatch cache by first attempting to start the watch from the last
resourceVersion. If a 410 Gone is detected it will fallback to the full
list call.