### PR TITLE
catch parse error in edge case of Log response handling

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -106,8 +106,12 @@ export class Log {
                     reject(error);
                     done(error);
                 } else if (response.statusCode !== 200) {
-                    const deserializedBody = ObjectSerializer.deserialize(JSON.parse(body), 'V1Status');
-                    reject(new HttpError(response, deserializedBody, response.statusCode));
+                    try {
+                        const deserializedBody = ObjectSerializer.deserialize(JSON.parse(body), 'V1Status');
+                        reject(new HttpError(response, deserializedBody, response.statusCode));
+                    } catch (e) {
+                        reject(new HttpError(response, body, response.statusCode));
+                    }
                     done(body);
                 } else {
                     done(null);


### PR DESCRIPTION
Followup fix to #703
In some edge cases the response form kubernetes log request can not be parsed as JSON if the response is not a 200, which results in application crashes, because the error is thrown in a callback and not handled.

The following error happens in production and the logs indicate that it is thrown sometimes in the JSON.parse call. Maybe the body is sometimes an empty string.
```
undefined:1


SyntaxError: Unexpected end of JSON input
    at JSON.parse (\u003canonymous\u003e)
    at Request._callback (/usr/src/app/node_modules/@kubernetes/client-node/dist/log.js:40:86)
...
```
I was not able to reproduce the error in my dev system and don't know in which case kubernetes does return an invalid json or if it is just an incomplete response. 

The fix prevents crashes by catching all possible errors and reject the promise. In this case an open question is which error should be used to reject the promise, because creating a `HttpError` object for an unknown parsing error feels wrong.