### PR TITLE
update kubernetes-client/gen

### DIFF
--- a/settings
+++ b/settings
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # kubernetes-client/gen commit to use for code generation.
-export GEN_COMMIT=d71ff1efd
+export GEN_COMMIT=a3aef4d
 
 # GitHub username/organization to clone kubernetes repo from.
 export USERNAME=kubernetes


### PR DESCRIPTION
We had problems regenerating our javascript client. After digging into it I've found this place where it uses a commit of `kubernetes-client/gen` which is over a year old and I updated it to the most recent commit hash.

I have no clue about all the implications this would have, but it works for us if we use this commit.