### PR TITLE
feat: Extract cluster server origin from server address

### DIFF
--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as _ from 'underscore';
-import {URL} from 'url';
 
 export enum ActionOnInvalid {
     THROW = 'throw',
@@ -28,10 +27,7 @@ export interface Cluster {
 export function newClusters(a: any, opts?: Partial<ConfigOptions>): Cluster[] {
     const options = Object.assign(defaultNewConfigOptions(), opts || {});
 
-    return _.compact(_.map(a, clusterIterator(options.onInvalidEntry))).map((cluster) => ({
-        ...cluster,
-        server: new URL(cluster.server).origin,
-    }));
+    return _.compact(_.map(a, clusterIterator(options.onInvalidEntry)));
 }
 
 export function exportCluster(cluster: Cluster): any {
@@ -62,7 +58,7 @@ function clusterIterator(onInvalidEntry: ActionOnInvalid): _.ListIterator<any, C
                 caData: elt.cluster['certificate-authority-data'],
                 caFile: elt.cluster['certificate-authority'],
                 name: elt.name,
-                server: elt.cluster.server,
+                server: elt.cluster.server.replace(/\/$/, ''),
                 skipTLSVerify: elt.cluster['insecure-skip-tls-verify'] === true,
             };
         } catch (err) {


### PR DESCRIPTION
This PR normalize the server address of the cluster. 

My problem was the wrong cluster server address in my .kube/config which works for other applications like Lens or kubectl.
There was `/` at the end of the cluster server address. So I aim to solve these kinds of problems with my current PR.

This PR is probably solving https://github.com/kubernetes-client/javascript/issues/674 this issue.