### PR TITLE
Update typescript open API generator to handle the IntOrString type

### DIFF
--- a/src/gen/model/v1HTTPGetAction.ts
+++ b/src/gen/model/v1HTTPGetAction.ts
@@ -11,6 +11,7 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 import { V1HTTPHeader } from './v1HTTPHeader';
 
 /**
@@ -30,9 +31,9 @@ export class V1HTTPGetAction {
     */
     'path'?: string;
     /**
-    * Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'port': object;
+    'port': IntOrString;
     /**
     * Scheme to use for connecting to the host. Defaults to HTTP.
     */
@@ -59,7 +60,7 @@ export class V1HTTPGetAction {
         {
             "name": "port",
             "baseName": "port",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "scheme",

--- a/src/gen/model/v1NetworkPolicyPort.ts
+++ b/src/gen/model/v1NetworkPolicyPort.ts
@@ -11,6 +11,7 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 
 /**
 * NetworkPolicyPort describes a port to allow traffic on
@@ -21,9 +22,9 @@ export class V1NetworkPolicyPort {
     */
     'endPort'?: number;
     /**
-    * The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'port'?: object;
+    'port'?: IntOrString;
     /**
     * The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
     */
@@ -40,7 +41,7 @@ export class V1NetworkPolicyPort {
         {
             "name": "port",
             "baseName": "port",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "protocol",

--- a/src/gen/model/v1PodDisruptionBudgetSpec.ts
+++ b/src/gen/model/v1PodDisruptionBudgetSpec.ts
@@ -11,6 +11,7 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 import { V1LabelSelector } from './v1LabelSelector';
 
 /**
@@ -18,13 +19,13 @@ import { V1LabelSelector } from './v1LabelSelector';
 */
 export class V1PodDisruptionBudgetSpec {
     /**
-    * An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\".
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'maxUnavailable'?: object;
+    'maxUnavailable'?: IntOrString;
     /**
-    * An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'minAvailable'?: object;
+    'minAvailable'?: IntOrString;
     'selector'?: V1LabelSelector;
 
     static discriminator: string | undefined = undefined;
@@ -33,12 +34,12 @@ export class V1PodDisruptionBudgetSpec {
         {
             "name": "maxUnavailable",
             "baseName": "maxUnavailable",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "minAvailable",
             "baseName": "minAvailable",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "selector",

--- a/src/gen/model/v1RollingUpdateDaemonSet.ts
+++ b/src/gen/model/v1RollingUpdateDaemonSet.ts
@@ -11,19 +11,20 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 
 /**
 * Spec to control the desired behavior of daemon set rolling update.
 */
 export class V1RollingUpdateDaemonSet {
     /**
-    * The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption. This is beta field and enabled/disabled by DaemonSetUpdateSurge feature gate.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'maxSurge'?: object;
+    'maxSurge'?: IntOrString;
     /**
-    * The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'maxUnavailable'?: object;
+    'maxUnavailable'?: IntOrString;
 
     static discriminator: string | undefined = undefined;
 
@@ -31,12 +32,12 @@ export class V1RollingUpdateDaemonSet {
         {
             "name": "maxSurge",
             "baseName": "maxSurge",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "maxUnavailable",
             "baseName": "maxUnavailable",
-            "type": "object"
+            "type": "IntOrString"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/gen/model/v1RollingUpdateDeployment.ts
+++ b/src/gen/model/v1RollingUpdateDeployment.ts
@@ -11,19 +11,20 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 
 /**
 * Spec to control the desired behavior of rolling update.
 */
 export class V1RollingUpdateDeployment {
     /**
-    * The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'maxSurge'?: object;
+    'maxSurge'?: IntOrString;
     /**
-    * The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'maxUnavailable'?: object;
+    'maxUnavailable'?: IntOrString;
 
     static discriminator: string | undefined = undefined;
 
@@ -31,12 +32,12 @@ export class V1RollingUpdateDeployment {
         {
             "name": "maxSurge",
             "baseName": "maxSurge",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "maxUnavailable",
             "baseName": "maxUnavailable",
-            "type": "object"
+            "type": "IntOrString"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/gen/model/v1ServicePort.ts
+++ b/src/gen/model/v1ServicePort.ts
@@ -11,6 +11,7 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 
 /**
 * ServicePort contains information on service\'s port.
@@ -37,9 +38,9 @@ export class V1ServicePort {
     */
     'protocol'?: string;
     /**
-    * Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod\'s container ports. If this is not specified, the value of the \'port\' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the \'port\' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'targetPort'?: object;
+    'targetPort'?: IntOrString;
 
     static discriminator: string | undefined = undefined;
 
@@ -72,7 +73,7 @@ export class V1ServicePort {
         {
             "name": "targetPort",
             "baseName": "targetPort",
-            "type": "object"
+            "type": "IntOrString"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/gen/model/v1TCPSocketAction.ts
+++ b/src/gen/model/v1TCPSocketAction.ts
@@ -11,6 +11,7 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 
 /**
 * TCPSocketAction describes an action based on opening a socket
@@ -21,9 +22,9 @@ export class V1TCPSocketAction {
     */
     'host'?: string;
     /**
-    * Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'port': object;
+    'port': IntOrString;
 
     static discriminator: string | undefined = undefined;
 
@@ -36,7 +37,7 @@ export class V1TCPSocketAction {
         {
             "name": "port",
             "baseName": "port",
-            "type": "object"
+            "type": "IntOrString"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/gen/model/v1beta1PodDisruptionBudgetSpec.ts
+++ b/src/gen/model/v1beta1PodDisruptionBudgetSpec.ts
@@ -11,6 +11,7 @@
  */
 
 import { RequestFile } from './models';
+import { IntOrString } from '../../types';
 import { V1LabelSelector } from './v1LabelSelector';
 
 /**
@@ -18,13 +19,13 @@ import { V1LabelSelector } from './v1LabelSelector';
 */
 export class V1beta1PodDisruptionBudgetSpec {
     /**
-    * An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\".
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'maxUnavailable'?: object;
+    'maxUnavailable'?: IntOrString;
     /**
-    * An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".
+    * IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.
     */
-    'minAvailable'?: object;
+    'minAvailable'?: IntOrString;
     'selector'?: V1LabelSelector;
 
     static discriminator: string | undefined = undefined;
@@ -33,12 +34,12 @@ export class V1beta1PodDisruptionBudgetSpec {
         {
             "name": "maxUnavailable",
             "baseName": "maxUnavailable",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "minAvailable",
             "baseName": "minAvailable",
-            "type": "object"
+            "type": "IntOrString"
         },
         {
             "name": "selector",

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,5 @@ export interface KubernetesListObject<T extends KubernetesObject> {
     metadata?: V1ListMeta;
     items: T[];
 }
+
+export type IntOrString = number | string;


### PR DESCRIPTION
Resolves https://github.com/kubernetes-client/javascript/issues/666

The 1 main change here is the addition of the `IntOrString` type to the `src/types.ts` file. The rest is the result of running
`GEN_ROOT=/home/alexbezek/code/gen npm run generate` and running `npm run build` to verify it compiles

Depends on https://github.com/kubernetes-client/gen/pull/213