### PR TITLE
Expand the concept of the homeDir on Windows

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -517,15 +517,18 @@ export function bufferFromFileOrString(file?: string, data?: string): Buffer | n
 }
 
 function dropDuplicatesAndNils(a: string[]): string[] {
-  return a.reduce((acceptedValues, currentValue) => {
-    // Good-enough algorithm for reducing a small (3 items at this point) array into an ordered list
-    // of unique non-empty strings.
-    if (currentValue && !acceptedValues.includes(currentValue)) {
-      return acceptedValues.concat(currentValue);
-    } else {
-      return acceptedValues;
-    }
-  }, [] as string[]);
+    return a.reduce(
+        (acceptedValues, currentValue) => {
+            // Good-enough algorithm for reducing a small (3 items at this point) array into an ordered list
+            // of unique non-empty strings.
+            if (currentValue && !acceptedValues.includes(currentValue)) {
+                return acceptedValues.concat(currentValue);
+            } else {
+                return acceptedValues;
+            }
+        },
+        [] as string[],
+    );
 }
 
 // Only public for testing.
@@ -542,8 +545,10 @@ export function findHomeDir(): string | null {
     }
     // $HOME is always favored, but the k8s go-client prefers the other two env vars
     // differently depending on whether .kube/config exists or not.
-    const homeDrivePath = process.env.HOMEDRIVE && process.env.HOMEPATH ?
-        path.join(process.env.HOMEDRIVE, process.env.HOMEPATH) : '';
+    const homeDrivePath =
+        process.env.HOMEDRIVE && process.env.HOMEPATH
+            ? path.join(process.env.HOMEDRIVE, process.env.HOMEPATH)
+            : '';
     const homePath = process.env.HOME || '';
     const userProfile = process.env.USERPROFILE || '';
     const favourHomeDrivePathList: string[] = dropDuplicatesAndNils([homePath, homeDrivePath, userProfile]);
@@ -560,7 +565,7 @@ export function findHomeDir(): string | null {
     for (const dir of favourUserProfileList) {
         try {
             const lstat = fs.lstatSync(dir);
-// tslint:disable-next-line:no-bitwise
+            // tslint:disable-next-line:no-bitwise
             if (lstat && (lstat.mode & fs.constants.S_IXUSR) === fs.constants.S_IXUSR) {
                 return dir;
             }

--- a/src/config.ts
+++ b/src/config.ts
@@ -516,7 +516,7 @@ export function bufferFromFileOrString(file?: string, data?: string): Buffer | n
     return null;
 }
 
-function dropDuplicatesAndNils(a): string[] {
+function dropDuplicatesAndNils(a: Array<string | null | undefined>): string[] {
   return a.reduce((acceptedValues, currentValue) => {
     // Good-enough algorithm for reducing a small (3 items at this point) array into an ordered list
     // of unique non-empty strings.
@@ -540,7 +540,8 @@ export function findHomeDir(): string | null {
         }
         return null;
     }
-    const homeDrivePath = process.env.HOMEDRIVE && process.env.HOMEPATH ? path.join(process.env.HOMEDRIVE, process.env.HOMEPATH) : null;
+    const homeDrivePath = process.env.HOMEDRIVE && process.env.HOMEPATH ?
+        path.join(process.env.HOMEDRIVE, process.env.HOMEPATH) : null;
     const dirList1: string[] = dropDuplicatesAndNils([process.env.HOME, homeDrivePath, process.env.USERPROFILE]);
     const dirList2: string[] = dropDuplicatesAndNils([process.env.HOME, process.env.USERPROFILE, homeDrivePath]);
     // 1. the first of %HOME%, %HOMEDRIVE%%HOMEPATH%, %USERPROFILE% containing a `.kube\config` file is returned.
@@ -555,7 +556,7 @@ export function findHomeDir(): string | null {
     for (const dir of dirList2) {
         try {
             const lstat = fs.lstatSync(dir);
-	    // tslint:disable-next-line:no-bitwise
+// tslint:disable-next-line:no-bitwise
             if (lstat && (lstat.mode & fs.constants.S_IXUSR) === fs.constants.S_IXUSR) {
                 return dir;
             }
@@ -570,8 +571,9 @@ export function findHomeDir(): string | null {
             // tslint:disable-next-line:no-empty
         } catch (ignore) {}
     }
-    // 4. if none of those locations exists, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that is set is returned.
-    return dirList2[0] ?? null;
+    // 4. if none of those locations exists, the first of
+    // %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that is set is returned.
+    return dirList2[0] || null;
 }
 
 export interface Named {

--- a/src/config.ts
+++ b/src/config.ts
@@ -516,7 +516,7 @@ export function bufferFromFileOrString(file?: string, data?: string): Buffer | n
     return null;
 }
 
-function dropDuplicatesAndNils(a: Array<string | null | undefined>): string[] {
+function dropDuplicatesAndNils(a: string[]): string[] {
   return a.reduce((acceptedValues, currentValue) => {
     // Good-enough algorithm for reducing a small (3 items at this point) array into an ordered list
     // of unique non-empty strings.
@@ -543,11 +543,11 @@ export function findHomeDir(): string | null {
     // $HOME is always favored, but the k8s go-client prefers the other two env vars
     // differently depending on whether .kube/config exists or not.
     const homeDrivePath = process.env.HOMEDRIVE && process.env.HOMEPATH ?
-        path.join(process.env.HOMEDRIVE, process.env.HOMEPATH) : null;
-    const favourHomeDrivePathList: string[] =
-        dropDuplicatesAndNils([process.env.HOME, homeDrivePath, process.env.USERPROFILE]);
-    const favourUserProfileList: string[] =
-        dropDuplicatesAndNils([process.env.HOME, process.env.USERPROFILE, homeDrivePath]);
+        path.join(process.env.HOMEDRIVE, process.env.HOMEPATH) : '';
+    const homePath = process.env.HOME || '';
+    const userProfile = process.env.USERPROFILE || '';
+    const favourHomeDrivePathList: string[] = dropDuplicatesAndNils([homePath, homeDrivePath, userProfile]);
+    const favourUserProfileList: string[] = dropDuplicatesAndNils([homePath, userProfile, homeDrivePath]);
     // 1. the first of %HOME%, %HOMEDRIVE%%HOMEPATH%, %USERPROFILE% containing a `.kube\config` file is returned.
     for (const dir of favourHomeDrivePathList) {
         try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -543,7 +543,7 @@ export function findHomeDir(): string | null {
         }
         return null;
     }
-    // $HOME is always favored, but the k8s go-client prefers the other two env vars
+    // $HOME is always favoured, but the k8s go-client prefers the other two env vars
     // differently depending on whether .kube/config exists or not.
     const homeDrivePath =
         process.env.HOMEDRIVE && process.env.HOMEPATH
@@ -564,11 +564,8 @@ export function findHomeDir(): string | null {
     // 2. ...the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists and is writeable is returned
     for (const dir of favourUserProfileList) {
         try {
-            const lstat = fs.lstatSync(dir);
-            // tslint:disable-next-line:no-bitwise
-            if (lstat && (lstat.mode & fs.constants.S_IXUSR) === fs.constants.S_IXUSR) {
-                return dir;
-            }
+            fs.accessSync(dir, fs.constants.W_OK);
+            return dir;
             // tslint:disable-next-line:no-empty
         } catch (ignore) {}
     }


### PR DESCRIPTION
Allow env vars HOME, HOMEDRIVE/HOMEPATH, and USERCONFIG to all
denote a possible home directory (call these *home-ish* directories).

Favour an existing .kube/config file

Favour existing, writable home-ish directories

And finally favour existing home-ish directories (which at this
point aren't writable, but that's how the Kubernetes go-client
does it).

Use the same determination of the .kube/config-based home dir on Windows
that the Kubernetes go-client uses