### PR TITLE
Add support for more quantity units

### DIFF
--- a/src/top_test.ts
+++ b/src/top_test.ts
@@ -29,7 +29,7 @@ const mockedPodMetrics: PodMetricsList = {
             },
             timestamp: '2021-09-26T11:57:21Z',
             window: '30s',
-            containers: [{ name: 'nginx', usage: { cpu: '5000000n', memory: '3912Ki' } }],
+            containers: [{ name: 'nginx', usage: { cpu: '50000000n', memory: '3912Ki' } }],
         },
         {
             metadata: {
@@ -42,7 +42,7 @@ const mockedPodMetrics: PodMetricsList = {
             window: '30s',
             containers: [
                 { name: 'nginx', usage: { cpu: '0', memory: '4012Ki' } },
-                { name: 'sidecar', usage: { cpu: '140000000n', memory: '3012Ki' } },
+                { name: 'sidecar', usage: { cpu: '1400000000n', memory: '3012Ki' } },
             ],
         },
     ],

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,9 +28,33 @@ export function quantityToScalar(quantity: string): number | bigint {
     }
     switch (suffix) {
         case 'n':
-            return Number(quantity.substr(0, quantity.length - 1)).valueOf() / 100_000_000.0;
+            return Number(quantity.substr(0, quantity.length - 1)).valueOf() / 1_000_000_000.0;
+        case 'u':
+            return Number(quantity.substr(0, quantity.length - 1)).valueOf() / 1_000_000.0;
         case 'm':
             return Number(quantity.substr(0, quantity.length - 1)).valueOf() / 1000.0;
+        case 'k':
+            return BigInt(quantity.substr(0, quantity.length - 1)) * BigInt(1000);
+        case 'M':
+            return BigInt(quantity.substr(0, quantity.length - 1)) * BigInt(1000 * 1000);
+        case 'G':
+            return BigInt(quantity.substr(0, quantity.length - 1)) * BigInt(1000 * 1000 * 1000);
+        case 'T':
+            return (
+                BigInt(quantity.substr(0, quantity.length - 1)) * BigInt(1000 * 1000 * 1000) * BigInt(1000)
+            );
+        case 'P':
+            return (
+                BigInt(quantity.substr(0, quantity.length - 1)) *
+                BigInt(1000 * 1000 * 1000) *
+                BigInt(1000 * 1000)
+            );
+        case 'E':
+            return (
+                BigInt(quantity.substr(0, quantity.length - 1)) *
+                BigInt(1000 * 1000 * 1000) *
+                BigInt(1000 * 1000 * 1000)
+            );
         case 'Ki':
             return BigInt(quantity.substr(0, quantity.length - 2)) * BigInt(1024);
         case 'Mi':

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -54,11 +54,21 @@ describe('Utils', () => {
     it('should parse quantities', () => {
         expect(quantityToScalar('')).to.equal(0);
 
+        expect(quantityToScalar('2n')).to.equal(2 / 1_000_000_000);
+        expect(quantityToScalar('3u')).to.equal(3 / 1_000_000);
         expect(quantityToScalar('100m')).to.equal(0.1);
+        expect(quantityToScalar('3k')).to.equal(BigInt(3000));
+        expect(quantityToScalar('3M')).to.equal(BigInt(3 * 1000 * 1000));
+        expect(quantityToScalar('3G')).to.equal(BigInt(3 * 1000 * 1000 * 1000));
+        expect(quantityToScalar('5T')).to.equal(BigInt(5 * 1000 * 1000 * 1000) * BigInt(1000));
+        expect(quantityToScalar('3P')).to.equal(BigInt(3 * 1000 * 1000 * 1000) * BigInt(1000 * 1000));
+        expect(quantityToScalar('14E')).to.equal(
+            BigInt(14 * 1000 * 1000 * 1000) * BigInt(1000 * 1000 * 1000),
+        );
+
         expect(quantityToScalar('0.2')).to.equal(0.2);
         expect(quantityToScalar('1976m')).to.equal(1.976);
 
-        expect(quantityToScalar('1024')).to.equal(1024);
         expect(quantityToScalar('1024')).to.equal(1024);
         expect(quantityToScalar('10e3')).to.equal(10000);
 


### PR DESCRIPTION
Adds support for missing decimal units: u, k, M, G, T, P and E.
Fixes multiplier for nano from 1e-8 to 1e-9.

Adds more units from #653, and should cover the full range of decimal units now.
Prevents the new `top` commands from crashing if any resource is using decimal units.