### PR TITLE
Add list method to generic KubernetesObjectApi

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -341,6 +341,7 @@ export class KubernetesObjectApi extends ApisApi {
         fieldSelector?: string,
         labelSelector?: string,
         limit?: number,
+        continueToken?: string,
         options: { headers: { [name: string]: string } } = { headers: {} },
     ): Promise<{ body: KubernetesListObject<KubernetesObject>; response: http.IncomingMessage }> {
         // verify required parameters 'apiVersion', 'kind' is not null or undefined
@@ -386,6 +387,10 @@ export class KubernetesObjectApi extends ApisApi {
 
         if (limit !== undefined) {
             localVarQueryParameters.limit = ObjectSerializer.serialize(limit, 'number');
+        }
+
+        if (continueToken !== undefined) {
+            localVarQueryParameters.continue = ObjectSerializer.serialize(continueToken, 'string');
         }
 
         const localVarRequestOptions: request.Options = {

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1751,7 +1751,7 @@ describe('KubernetesObject', () => {
         it('should list resources in a namespace', async () => {
             const scope = nock('https://d.i.y')
                 .get(
-                    '/api/v1/namespaces/default/secrets?fieldSelector=metadata.name%3Dtest-secret1&labelSelector=app%3Dmy-app&limit=5',
+                    '/api/v1/namespaces/default/secrets?fieldSelector=metadata.name%3Dtest-secret1&labelSelector=app%3Dmy-app&limit=5&continue=abc',
                 )
                 .reply(200, {
                     apiVersion: 'v1',
@@ -1768,6 +1768,7 @@ describe('KubernetesObject', () => {
                     ],
                     metadata: {
                         resourceVersion: '216532459',
+                        continue: 'abc',
                     },
                 });
             const lr = await client.list(
@@ -1780,6 +1781,7 @@ describe('KubernetesObject', () => {
                 'metadata.name=test-secret1',
                 'app=my-app',
                 5,
+                'abc',
             );
             const items = lr.body.items;
             expect(items).to.have.length(1);
@@ -1806,6 +1808,7 @@ describe('KubernetesObject', () => {
                     ],
                     metadata: {
                         resourceVersion: '216532459',
+                        continue: 'abc',
                     },
                 });
             const lr = await client.list(


### PR DESCRIPTION
This PR implements a list method on the generic `KubernetesObjectApi`.
I created a new PR for that feature as the original PR (https://github.com/kubernetes-client/javascript/pull/588), that wanted to implement this feature, has been closed due to inactivity.

In addition the list method supports:
- an optional namespace selector
- fieldselector
- labelselector
- limit + continue token