### PR TITLE
fix(cache): update cache with O(1) data structures

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -20,19 +20,23 @@ export interface ObjectCache<T> {
     list(namespace?: string): ReadonlyArray<T>;
 }
 
+// exported for testing
+export type CacheMap<T extends KubernetesObject> = Map<string, Map<string, T>>;
+
 export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, Informer<T> {
-    private objects: T[] = [];
+    private objects: CacheMap<T> = new Map();
     private resourceVersion: string;
-    private readonly indexCache: { [key: string]: T[] } = {};
-    private readonly callbackCache: { [key: string]: Array<ObjectCallback<T> | ErrorCallback> } = {};
+    private readonly callbackCache: {
+        [key: string]: Array<ObjectCallback<T> | ErrorCallback>;
+    } = {};
     private request: RequestResult | undefined;
-    private stopped: boolean = false;
+    private stopped = false;
 
     public constructor(
         private readonly path: string,
         private readonly watch: Watch,
         private readonly listFn: ListPromise<T>,
-        autoStart: boolean = true,
+        autoStart = true,
         private readonly labelSelector?: string,
     ) {
         this.callbackCache[ADD] = [];
@@ -93,18 +97,19 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
     }
 
     public get(name: string, namespace?: string): T | undefined {
-        return this.objects.find(
-            (obj: T): boolean => {
-                return obj.metadata!.name === name && (!namespace || obj.metadata!.namespace === namespace);
-            },
-        );
+        const nsObjects = this.objects.get(namespace || '');
+        if (nsObjects) {
+            return nsObjects.get(name);
+        }
+        return undefined;
     }
 
     public list(namespace?: string | undefined): ReadonlyArray<T> {
-        if (!namespace) {
-            return this.objects;
+        const namespaceObjects = this.objects.get(namespace || '');
+        if (!namespaceObjects) {
+            return [];
         }
-        return this.indexCache[namespace] as ReadonlyArray<T>;
+        return Array.from(namespaceObjects.values());
     }
 
     public latestResourceVersion(): string {
@@ -118,7 +123,7 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
         }
     }
 
-    private async doneHandler(err: any): Promise<any> {
+    private async doneHandler(err: unknown): Promise<void> {
         this._stop();
         if (
             err &&
@@ -139,16 +144,8 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
             const result = await promise;
             const list = result.body;
             this.objects = deleteItems(this.objects, list.items, this.callbackCache[DELETE].slice());
-            Object.keys(this.indexCache).forEach((key) => {
-                const updateObjects = deleteItems(this.indexCache[key], list.items);
-                if (updateObjects.length !== 0) {
-                    this.indexCache[key] = updateObjects;
-                } else {
-                    delete this.indexCache[key];
-                }
-            });
             this.addOrUpdateItems(list.items);
-            this.resourceVersion = list.metadata!.resourceVersion!;
+            this.resourceVersion = list.metadata!.resourceVersion || '';
         }
         const queryParams = {
             resourceVersion: this.resourceVersion,
@@ -175,19 +172,7 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
                 this.callbackCache[ADD].slice(),
                 this.callbackCache[UPDATE].slice(),
             );
-            if (obj.metadata!.namespace) {
-                this.indexObj(obj);
-            }
         });
-    }
-
-    private indexObj(obj: T): void {
-        let namespaceList = this.indexCache[obj.metadata!.namespace!] as T[];
-        if (!namespaceList) {
-            namespaceList = [];
-            this.indexCache[obj.metadata!.namespace!] = namespaceList;
-        }
-        addOrUpdateObject(namespaceList, obj);
     }
 
     private async watchHandler(
@@ -204,18 +189,9 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
                     this.callbackCache[ADD].slice(),
                     this.callbackCache[UPDATE].slice(),
                 );
-                if (obj.metadata!.namespace) {
-                    this.indexObj(obj);
-                }
                 break;
             case 'DELETED':
                 deleteObject(this.objects, obj, this.callbackCache[DELETE].slice());
-                if (obj.metadata!.namespace) {
-                    const namespaceList = this.indexCache[obj.metadata!.namespace!] as T[];
-                    if (namespaceList) {
-                        deleteObject(namespaceList, obj);
-                    }
-                }
                 break;
             case 'BOOKMARK':
                 // nothing to do, here for documentation, mostly.
@@ -228,48 +204,81 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
     }
 }
 
+// exported for testing
+export function cacheMapFromList<T extends KubernetesObject>(newObjects: T[]): CacheMap<T> {
+    const objects: CacheMap<T> = new Map();
+    // build up the new list
+    for (const obj of newObjects) {
+        let namespaceObjects = objects.get(obj.metadata!.namespace || '');
+        if (!namespaceObjects) {
+            namespaceObjects = new Map();
+            objects.set(obj.metadata!.namespace || '', namespaceObjects);
+        }
+
+        const name = obj.metadata!.name || '';
+        namespaceObjects.set(name, obj);
+    }
+    return objects;
+}
+
 // external for testing
 export function deleteItems<T extends KubernetesObject>(
-    oldObjects: T[],
+    oldObjects: CacheMap<T>,
     newObjects: T[],
     deleteCallback?: Array<ObjectCallback<T>>,
-): T[] {
-    return oldObjects.filter((obj: T) => {
-        if (findKubernetesObject(newObjects, obj) === -1) {
-            if (deleteCallback) {
-                deleteCallback.forEach((fn: ObjectCallback<T>) => fn(obj));
+): CacheMap<T> {
+    const objects = cacheMapFromList(newObjects);
+
+    if (!deleteCallback) {
+        return objects;
+    }
+
+    for (const [namespace, oldNamespaceObjects] of oldObjects.entries()) {
+        const newNamespaceObjects = objects.get(namespace);
+        if (newNamespaceObjects) {
+            for (const [name, oldObj] of oldNamespaceObjects.entries()) {
+                if (newNamespaceObjects.has(name)) {
+                    deleteCallback.forEach((fn: ObjectCallback<T>) => fn(oldObj));
+                }
             }
-            return false;
+        } else {
+            oldNamespaceObjects.forEach((obj: T) => {
+                deleteCallback.forEach((fn: ObjectCallback<T>) => fn(obj));
+            });
         }
-        return true;
-    });
+    }
+
+    return objects;
 }
 
 // Only public for testing.
 export function addOrUpdateObject<T extends KubernetesObject>(
-    objects: T[],
+    objects: CacheMap<T>,
     obj: T,
     addCallback?: Array<ObjectCallback<T>>,
     updateCallback?: Array<ObjectCallback<T>>,
 ): void {
-    const ix = findKubernetesObject(objects, obj);
-    if (ix === -1) {
-        objects.push(obj);
+    let namespaceObjects = objects.get(obj.metadata!.namespace || '');
+    if (!namespaceObjects) {
+        namespaceObjects = new Map();
+        objects.set(obj.metadata!.namespace || '', namespaceObjects);
+    }
+
+    const name = obj.metadata!.name || '';
+    const found = namespaceObjects.get(name);
+    if (!found) {
+        namespaceObjects.set(name, obj);
         if (addCallback) {
             addCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
         }
     } else {
-        if (!isSameVersion(objects[ix], obj)) {
-            objects[ix] = obj;
+        if (!isSameVersion(found, obj)) {
+            namespaceObjects.set(name, obj);
             if (updateCallback) {
                 updateCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
             }
         }
     }
-}
-
-function isSameObject<T extends KubernetesObject>(o1: T, o2: T): boolean {
-    return o1.metadata!.name === o2.metadata!.name && o1.metadata!.namespace === o2.metadata!.namespace;
 }
 
 function isSameVersion<T extends KubernetesObject>(o1: T, o2: T): boolean {
@@ -280,23 +289,26 @@ function isSameVersion<T extends KubernetesObject>(o1: T, o2: T): boolean {
     );
 }
 
-function findKubernetesObject<T extends KubernetesObject>(objects: T[], obj: T): number {
-    return objects.findIndex((elt: T) => {
-        return isSameObject(elt, obj);
-    });
-}
-
 // Public for testing.
 export function deleteObject<T extends KubernetesObject>(
-    objects: T[],
+    objects: CacheMap<T>,
     obj: T,
     deleteCallback?: Array<ObjectCallback<T>>,
 ): void {
-    const ix = findKubernetesObject(objects, obj);
-    if (ix !== -1) {
-        objects.splice(ix, 1);
+    const namespace = obj.metadata!.namespace || '';
+    const name = obj.metadata!.name || '';
+
+    const namespaceObjects = objects.get(namespace);
+    if (!namespaceObjects) {
+        return;
+    }
+    const deleted = namespaceObjects.delete(name);
+    if (deleted) {
         if (deleteCallback) {
             deleteCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
+        }
+        if (namespaceObjects.size === 0) {
+            objects.delete(namespace);
         }
     }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -30,13 +30,13 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
         [key: string]: Array<ObjectCallback<T> | ErrorCallback>;
     } = {};
     private request: RequestResult | undefined;
-    private stopped = false;
+    private stopped: boolean = false;
 
     public constructor(
         private readonly path: string,
         private readonly watch: Watch,
         private readonly listFn: ListPromise<T>,
-        autoStart = true,
+        autoStart: boolean = true,
         private readonly labelSelector?: string,
     ) {
         this.callbackCache[ADD] = [];

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -264,8 +264,8 @@ export function deleteItems<T extends KubernetesObject>(
 export function addOrUpdateObject<T extends KubernetesObject>(
     objects: CacheMap<T>,
     obj: T,
-    addCallback?: Array<ObjectCallback<T>>,
-    updateCallback?: Array<ObjectCallback<T>>,
+    addCallbacks?: Array<ObjectCallback<T>>,
+    updateCallbacks?: Array<ObjectCallback<T>>,
 ): void {
     let namespaceObjects = objects.get(obj.metadata!.namespace || '');
     if (!namespaceObjects) {
@@ -277,14 +277,14 @@ export function addOrUpdateObject<T extends KubernetesObject>(
     const found = namespaceObjects.get(name);
     if (!found) {
         namespaceObjects.set(name, obj);
-        if (addCallback) {
-            addCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
+        if (addCallbacks) {
+            addCallbacks.forEach((elt: ObjectCallback<T>) => elt(obj));
         }
     } else {
         if (!isSameVersion(found, obj)) {
             namespaceObjects.set(name, obj);
-            if (updateCallback) {
-                updateCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
+            if (updateCallbacks) {
+                updateCallbacks.forEach((elt: ObjectCallback<T>) => elt(obj));
             }
         }
     }
@@ -302,7 +302,7 @@ function isSameVersion<T extends KubernetesObject>(o1: T, o2: T): boolean {
 export function deleteObject<T extends KubernetesObject>(
     objects: CacheMap<T>,
     obj: T,
-    deleteCallback?: Array<ObjectCallback<T>>,
+    deleteCallbacks?: Array<ObjectCallback<T>>,
 ): void {
     const namespace = obj.metadata!.namespace || '';
     const name = obj.metadata!.name || '';
@@ -313,8 +313,8 @@ export function deleteObject<T extends KubernetesObject>(
     }
     const deleted = namespaceObjects.delete(name);
     if (deleted) {
-        if (deleteCallback) {
-            deleteCallback.forEach((elt: ObjectCallback<T>) => elt(obj));
+        if (deleteCallbacks) {
+            deleteCallbacks.forEach((elt: ObjectCallback<T>) => elt(obj));
         }
         if (namespaceObjects.size === 0) {
             objects.delete(namespace);

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -116,7 +116,7 @@ describe('ListWatchCache', () => {
             ],
         } as V1NamespaceList;
 
-        var calls = 0;
+        let calls = 0;
         const listFn: ListPromise<V1Namespace> = function(): Promise<{
             response: http.IncomingMessage;
             body: V1NamespaceList;
@@ -144,11 +144,11 @@ describe('ListWatchCache', () => {
         expect(pathOut).to.equal('/some/path');
         expect(cache.list()).to.deep.equal(list);
 
-        expect(cache.get('name1')).to.equal(list[0]);
-        expect(cache.get('name2')).to.equal(list[1]);
+        expect(cache.get('name1', 'default')).to.equal(list[0]);
+        expect(cache.get('name2', 'default')).to.equal(list[1]);
 
         expect(cache.list('default')).to.deep.equal(list);
-        expect(cache.list('non-existent')).to.be.undefined;
+        expect(cache.list('non-existent')).to.deep.equal([]);
 
         watchHandler('ADDED', {
             metadata: {
@@ -158,11 +158,11 @@ describe('ListWatchCache', () => {
         } as V1Namespace);
 
         expect(cache.list().length).to.equal(3);
-        expect(cache.get('name3')).to.not.equal(null);
+        expect(cache.get('name3', 'default')).to.not.equal(null);
 
         expect(cache.list('default').length).to.equal(2);
         expect(cache.list('other').length).to.equal(1);
-        expect(cache.list('non-existent')).to.be.undefined;
+        expect(cache.list('non-existent')).to.deep.equal([]);
 
         watchHandler('MODIFIED', {
             metadata: {
@@ -172,7 +172,7 @@ describe('ListWatchCache', () => {
             } as V1ObjectMeta,
         } as V1Namespace);
         expect(cache.list().length).to.equal(3);
-        const obj3 = cache.get('name3');
+        const obj3 = cache.get('name3', 'other');
         expect(obj3).to.not.equal(null);
         if (obj3) {
             expect(obj3.metadata!.name).to.equal('name3');
@@ -186,7 +186,7 @@ describe('ListWatchCache', () => {
             } as V1ObjectMeta,
         } as V1Namespace);
         expect(cache.list().length).to.equal(2);
-        expect(cache.get('name2')).to.equal(undefined);
+        expect(cache.get('name2', 'default')).to.equal(undefined);
 
         expect(cache.list('default').length).to.equal(1);
         expect(cache.list('other').length).to.equal(1);
@@ -203,7 +203,7 @@ describe('ListWatchCache', () => {
         await doneHandler(error);
         expect(cache.list().length, 'all namespace list').to.equal(1);
         expect(cache.list('default').length, 'default namespace list').to.equal(1);
-        expect(cache.list('other'), 'other namespace list').to.be.undefined;
+        expect(cache.list('other'), 'other namespace list').to.deep.equal([]);
     });
 
     it('should perform work as an informer', async () => {
@@ -635,8 +635,8 @@ describe('ListWatchCache', () => {
         expect(pathOut).to.equal('/some/path');
         expect(cache.list()).to.deep.equal(list);
 
-        expect(cache.get('name1')).to.equal(list[0]);
-        expect(cache.get('name2')).to.equal(list[1]);
+        expect(cache.get('name1', 'ns1')).to.equal(list[0]);
+        expect(cache.get('name2', 'ns2')).to.equal(list[1]);
 
         expect(cache.list('ns1').length).to.equal(1);
         expect(cache.list('ns1')[0].metadata!.name).to.equal('name1');

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -17,6 +17,7 @@ import { ADD, UPDATE, DELETE, ERROR, ListPromise, CHANGE } from './informer';
 use(chaiAsPromised);
 
 import { DefaultRequest, RequestResult, Watch } from './watch';
+import { getPriority } from 'os';
 
 // Object replacing real Request object in the test
 class FakeRequest extends EventEmitter implements RequestResult {
@@ -710,8 +711,8 @@ describe('ListWatchCache', () => {
             },
         } as V1Pod);
         expect(cache.size).to.equal(2);
-        expect(cache.get('ns1').size).to.equal(1);
-        expect(cache.get('ns2').size).to.equal(1);
+        expect((cache.get('ns1') || new Map()).size).to.equal(1);
+        expect((cache.get('ns2') || new Map()).size).to.equal(1);
         deleteObject(cache, {
             metadata: {
                 name: 'name1',
@@ -719,8 +720,8 @@ describe('ListWatchCache', () => {
             },
         } as V1Pod);
         expect(cache.size).to.equal(2);
-        expect(cache.get('ns1').size).to.equal(1);
-        expect(cache.get('ns2').size).to.equal(1);
+        expect((cache.get('ns1') || new Map()).size).to.equal(1);
+        expect((cache.get('ns2') || new Map()).size).to.equal(1);
         deleteObject(cache, {
             metadata: {
                 name: 'name1',
@@ -729,7 +730,7 @@ describe('ListWatchCache', () => {
         } as V1Pod);
         expect(cache.size).to.equal(1);
         expect(cache.has('ns1')).to.equal(false);
-        expect(cache.get('ns2').size).to.equal(1);
+        expect((cache.get('ns2') || new Map()).size).to.equal(1);
     });
 
     it('should not call handlers which have been unregistered', async () => {

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -17,7 +17,6 @@ import { ADD, UPDATE, DELETE, ERROR, ListPromise, CHANGE } from './informer';
 use(chaiAsPromised);
 
 import { DefaultRequest, RequestResult, Watch } from './watch';
-import { getPriority } from 'os';
 
 // Object replacing real Request object in the test
 class FakeRequest extends EventEmitter implements RequestResult {


### PR DESCRIPTION
The prior implementation used arrays to store cached objects. This meant
that updates were O(n). In a controller I developed that managed ~70k PV
and ~70k pvc 99.9% of CPU time was spent in cache updates pegging the
entire process. This new implementation doesn't even have cache updates
show up in the profiles and is using ~25m cpu for the same number of
objects.
