### PR TITLE
makeInformer returns Informer & ObjectCache

### DIFF
--- a/src/informer.ts
+++ b/src/informer.ts
@@ -1,4 +1,4 @@
-import { ListWatch } from './cache';
+import { ListWatch, ObjectCache } from './cache';
 import { KubeConfig } from './config';
 import { KubernetesListObject, KubernetesObject } from './types';
 import { Watch } from './watch';
@@ -36,7 +36,7 @@ export function makeInformer<T>(
     path: string,
     listPromiseFn: ListPromise<T>,
     labelSelector?: string,
-): Informer<T> {
+): Informer<T> & ObjectCache<T> {
     const watch = new Watch(kubeconfig);
     return new ListWatch<T>(path, watch, listPromiseFn, false, labelSelector);
 }


### PR DESCRIPTION
makeInformer currently returns the ListWatch object implements Informer interface.
In addition that, it also implements ObjectCache interface.

ObjectCache is very useful to implements kubernetes controller, but to use ObjectCache methods, we can't achieve the benefit of typescript type checking, because makeInformer returns the value as Informer interface.
In this PR, makeInformer returns the value as Informer & ObjectCache in order to accurate the typescript type check.
Maybe we should define new interface for that.