### PR TITLE
example/ts/informer: avoid staleness by adding a timeout

### DIFF
--- a/examples/typescript/informer/informer-with-label-selector.ts
+++ b/examples/typescript/informer/informer-with-label-selector.ts
@@ -8,13 +8,19 @@ const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
 const APP_LABEL_SELECTOR = 'app=foo';
 
+// timeout based on discussions in https://github.com/kubernetes-client/javascript/issues/596
 const listFn = () => k8sApi.listNamespacedPod(
-    'default',
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    APP_LABEL_SELECTOR,
+    'default', // namespace: string
+    undefined, // pretty?: string
+    undefined, // allowWatchBookmarks?: boolean
+    undefined, // _continue?: string
+    undefined, // fieldSelector?: string
+    APP_LABEL_SELECTOR, // labelSelector?: string
+    undefined, // limit?: number
+    undefined, // resourceVersion?: string
+    undefined, // resourceVersionMatch?: string
+    300 // timeoutSeconds?: number
+    // keep watch field false (default)
 );
 
 const createPod = async (name, app) => {

--- a/examples/typescript/informer/informer.ts
+++ b/examples/typescript/informer/informer.ts
@@ -6,7 +6,20 @@ kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-const listFn = () => k8sApi.listNamespacedPod('default');
+// timeout based on discussions in https://github.com/kubernetes-client/javascript/issues/596
+const listFn = () => k8sApi.listNamespacedPod(
+    'default', // namespace: string
+    undefined, // pretty?: string
+    undefined, // allowWatchBookmarks?: boolean
+    undefined, // _continue?: string
+    undefined, // fieldSelector?: string
+    undefined, // labelSelector?: string
+    undefined, // limit?: number
+    undefined, // resourceVersion?: string
+    undefined, // resourceVersionMatch?: string
+    300 // timeoutSeconds?: number
+    // keep watch field false (default)
+);
 
 const informer = k8s.makeInformer(kc, '/api/v1/namespaces/default/pods', listFn);
 


### PR DESCRIPTION
Based on my experience with #596, such a timeout seems to help. Seems like a good idea to add it to the example in the documentation.