### PR TITLE
Make the Informer interface more strict

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -60,13 +60,16 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
         this._stop();
     }
 
-    public on(verb: 'add' | 'update' | 'delete' | 'change', cb: ObjectCallback<T>): void;
-    public on(verb: 'error' | 'connect', cb: ErrorCallback): void;
-    public on(verb: string, cb: any): void {
+    public on(verb: ADD | UPDATE | DELETE | CHANGE, cb: ObjectCallback<T>): void;
+    public on(verb: ERROR | CONNECT, cb: ErrorCallback): void;
+    public on(
+        verb: ADD | UPDATE | DELETE | CHANGE | ERROR | CONNECT,
+        cb: ObjectCallback<T> | ErrorCallback,
+    ): void {
         if (verb === CHANGE) {
-            this.on('add', cb);
-            this.on('update', cb);
-            this.on('delete', cb);
+            this.on(ADD, cb);
+            this.on(UPDATE, cb);
+            this.on(DELETE, cb);
             return;
         }
         if (this.callbackCache[verb] === undefined) {
@@ -75,13 +78,16 @@ export class ListWatch<T extends KubernetesObject> implements ObjectCache<T>, In
         this.callbackCache[verb].push(cb);
     }
 
-    public off(verb: 'add' | 'update' | 'delete' | 'change', cb: ObjectCallback<T>): void;
-    public off(verb: 'error' | 'connect', cb: ErrorCallback): void;
-    public off(verb: string, cb: any): void {
+    public off(verb: ADD | UPDATE | DELETE | CHANGE, cb: ObjectCallback<T>): void;
+    public off(verb: ERROR | CONNECT, cb: ErrorCallback): void;
+    public off(
+        verb: ADD | UPDATE | DELETE | CHANGE | ERROR | CONNECT,
+        cb: ObjectCallback<T> | ErrorCallback,
+    ): void {
         if (verb === CHANGE) {
-            this.off('add', cb);
-            this.off('update', cb);
-            this.off('delete', cb);
+            this.off(ADD, cb);
+            this.off(UPDATE, cb);
+            this.off(DELETE, cb);
             return;
         }
         if (this.callbackCache[verb] === undefined) {

--- a/src/informer.ts
+++ b/src/informer.ts
@@ -14,19 +14,27 @@ export type ListPromise<T extends KubernetesObject> = () => Promise<{
 }>;
 
 // These are issued per object
-export const ADD: string = 'add';
-export const UPDATE: string = 'update';
-export const CHANGE: string = 'change';
-export const DELETE: string = 'delete';
+export const ADD = 'add';
+export type ADD = typeof ADD;
+export const UPDATE = 'update';
+export type UPDATE = typeof UPDATE;
+export const CHANGE = 'change';
+export type CHANGE = typeof CHANGE;
+export const DELETE = 'delete';
+export type DELETE = typeof DELETE;
 
 // This is issued when a watch connects or reconnects
-export const CONNECT: string = 'connect';
+export const CONNECT = 'connect';
+export type CONNECT = typeof CONNECT;
 // This is issued when there is an error
-export const ERROR: string = 'error';
+export const ERROR = 'error';
+export type ERROR = typeof ERROR;
 
 export interface Informer<T> {
-    on(verb: string, fn: ObjectCallback<T>): void;
-    off(verb: string, fn: ObjectCallback<T>): void;
+    on(verb: ADD | UPDATE | DELETE | CHANGE, cb: ObjectCallback<T>): void;
+    on(verb: ERROR | CONNECT, cb: ErrorCallback): void;
+    off(verb: ADD | UPDATE | DELETE | CHANGE, cb: ObjectCallback<T>): void;
+    off(verb: ERROR | CONNECT, cb: ErrorCallback): void;
     start(): Promise<void>;
     stop(): Promise<void>;
 }


### PR DESCRIPTION
The `on` and `off` functions of the ListWatch class and the Informer interface accept a string type as their first argument. In fact, they only accept add, delete, update, change, error, and connect.
Furthermore, the type of the second argument is determined by the first argument.
To find errors at compile, this PR makes the Informer and ListWatch more strict.