### PR TITLE
Support to serialize MicroTime fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,9 @@ export interface KubernetesListObject<T extends KubernetesObject> {
 }
 
 export type IntOrString = number | string;
+
+export class V1MicroTime extends Date {
+    public toISOString(): string {
+        return super.toISOString().slice(0, -1) + '000Z';
+    }
+}


### PR DESCRIPTION
Some Kubernetes objects expect to have date fields represented RFC3339 format with microsecond.
However, Kubernetes is unable to represent microsecond field in openapi schema.
ref: https://github.com/kubernetes/kubernetes/issues/97904

In this PR, patch the kubernetes/gen which generate clients based on the open api schema generated by kubernetes, and define V1MicroTime to represent microseconds.
I confirmed the below code works.

```typescript
import * as k8s from "@kubernetes/client-node";

async function main(): Promise<void> {
  const config = new k8s.KubeConfig();
  config.loadFromDefault();

  const cli = config.makeApiClient(k8s.CoordinationV1Api);
  await cli.createNamespacedLease("default", {
    metadata: {
      name: "foo",
      namespace: "default",
    },
    spec: {
      acquireTime: new k8s.V1MicroTime(),
      holderIdentity: "foo",
    },
  });
}

(async () => {
  await main();
})()
```

ref: https://github.com/kubernetes-client/javascript/issues/828