### PR TITLE
Add comment about patching custom resources on apply example

### DIFF
--- a/examples/typescript/apply/apply-example.ts
+++ b/examples/typescript/apply/apply-example.ts
@@ -31,6 +31,11 @@ export async function apply(specPath: string): Promise<k8s.KubernetesObject[]> {
             // block.
             await client.read(spec);
             // we got the resource, so it exists, so patch it
+            //
+            // Note that this could fail if the spec refers to a custom resource. For custom resources you may need to specify
+            // a different patch merge strategy in the content-type header.
+            //
+            // See: https://github.com/kubernetes/kubernetes/issues/97423
             const response = await client.patch(spec);
             created.push(response.body);
         } catch (e) {

--- a/examples/typescript/apply/apply-example.ts
+++ b/examples/typescript/apply/apply-example.ts
@@ -32,8 +32,8 @@ export async function apply(specPath: string): Promise<k8s.KubernetesObject[]> {
             await client.read(spec);
             // we got the resource, so it exists, so patch it
             //
-            // Note that this could fail if the spec refers to a custom resource. For custom resources you may need to specify
-            // a different patch merge strategy in the content-type header.
+            // Note that this could fail if the spec refers to a custom resource. For custom resources you may need
+            // to specify a different patch merge strategy in the content-type header.
             //
             // See: https://github.com/kubernetes/kubernetes/issues/97423
             const response = await client.patch(spec);


### PR DESCRIPTION
When running a `patch` operation on a custom resource the default strategic merge strategy can fail. Since it's difficult to identify custom resources, we leave a note to the developer that they need to be aware of this when using this example code.

See: #838