### PR TITLE
fix: bumped up [at]types/tar to fix the error TS2709: Cannot use namespace 'MiniPass' as a type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "isomorphic-ws": "^4.0.1",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^0.19.0",
+        "minipass": "^3.3.5",
         "request": "^2.88.0",
         "rfc4648": "^1.3.0",
         "shelljs": "^0.8.5",
@@ -2333,9 +2334,9 @@
       "dev": true
     },
     "node_modules/minipass": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.5.tgz",
+      "integrity": "sha512-rQ/p+KfKBkeNwo04U15i+hOwoVBVmekmm/HcfTkTN2t9pbQKCMm4eN5gFeqgrrSp/kH/7BYYhTIHOxGqzbBPaA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6155,9 +6156,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.5.tgz",
+      "integrity": "sha512-rQ/p+KfKBkeNwo04U15i+hOwoVBVmekmm/HcfTkTN2t9pbQKCMm4eN5gFeqgrrSp/kH/7BYYhTIHOxGqzbBPaA==",
       "requires": {
         "yallist": "^4.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^10.12.0",
         "@types/request": "^2.47.1",
         "@types/stream-buffers": "^3.0.3",
-        "@types/tar": "^4.0.3",
+        "@types/tar": "^6.1.1",
         "@types/underscore": "^1.8.9",
         "@types/ws": "^6.0.1",
         "byline": "^5.0.0",
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@types/tar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
-      "integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.1.tgz",
+      "integrity": "sha512-8mto3YZfVpqB1CHMaYz1TUYIQfZFbh/QbEq5Hsn6D0ilCfqRVCdalmc89B7vi3jhl9UYIk+dWDABShNfOkv5HA==",
       "dependencies": {
         "@types/minipass": "*",
         "@types/node": "*"
@@ -4736,9 +4736,9 @@
       }
     },
     "@types/tar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
-      "integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.1.tgz",
+      "integrity": "sha512-8mto3YZfVpqB1CHMaYz1TUYIQfZFbh/QbEq5Hsn6D0ilCfqRVCdalmc89B7vi3jhl9UYIk+dWDABShNfOkv5HA==",
       "requires": {
         "@types/minipass": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^10.12.0",
     "@types/request": "^2.47.1",
     "@types/stream-buffers": "^3.0.3",
-    "@types/tar": "^4.0.3",
+    "@types/tar": "^6.1.1",
     "@types/underscore": "^1.8.9",
     "@types/ws": "^6.0.1",
     "byline": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "isomorphic-ws": "^4.0.1",
     "js-yaml": "^4.1.0",
     "jsonpath-plus": "^0.19.0",
+    "minipass": "^3.3.5",
     "request": "^2.88.0",
     "rfc4648": "^1.3.0",
     "shelljs": "^0.8.5",


### PR DESCRIPTION
For my application with dependencies:
```json
{
  "dependencies": {
    "@kubernetes/client-node": "^0.17.0",
    "aws-sdk": "^2.1181.0",
    "dotenv": "^16.0.1",
    "request": "^2.88.2",
    "request-promise": "^4.2.6",
    "winston": "^3.8.1"
  },
  "devDependencies": {
    "@types/jest": "^28.1.6",
    "@types/request": "^2.48.8",
    "@types/request-promise": "^4.1.48",
    "core-js": "^3.24.0",
    "jest": "^28.1.3",
    "jest-coverage-badges": "^1.1.2",
    "nock": "^13.2.9",
    "ts-jest": "^28.0.7",
    "typemoq": "^2.1.0",
    "typescript": "^4.7.4"
  }
}
```
`npx tsc` is failing because:

```
node_modules/@types/tar/index.d.ts:252:36 - error TS2709: Cannot use namespace 'MiniPass' as a type.
252 export interface ReadEntry extends MiniPass, HeaderProperties {
                                       ~~~~~~~~
Found 1 error in node_modules/@types/tar/index.d.ts:252
```

Bumping up the version of `@types/tar` from 4.x to 6.x matching `tar` and added explicit dependency to `minipass` solve the problem.

Refer to https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60901?sort=top#discussioncomment-3217607