### PR TITLE
Fix typedoc unable to find entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "nyc mocha",
     "prepare": "npm run build",
     "prepack": "npm run build",
-    "docs": "typedoc src/gen/api"
+    "docs": "typedoc src/gen/api.ts"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Typedoc is unable to find the entry point file resulting in the documentation action failing.

https://github.com/kubernetes-client/javascript/runs/7962403223

Looks like it is because it is configured to look inside the api folder and fails to find the entry point automatically.

https://github.com/kubernetes-client/javascript/blob/51e1487395c315d2bc97820afd9770a5199b0d37/package.json#L30

 It is fixed by telling typedoc to use src/gen/api.ts as the entry file.