### PR TITLE
consider tar return code when cpToPod

### DIFF
--- a/src/cp.ts
+++ b/src/cp.ts
@@ -40,8 +40,8 @@ export class Cp {
             errStream,
             null,
             false,
-            async () => {
-                if (errStream.size()) {
+            async ({status}) => {
+                if (status === 'Failure' && errStream.size()) {
                     throw new Error(`Error from cpFromPod - details: \n ${errStream.getContentsAsString()}`);
                 }
                 await tar.x({


### PR DESCRIPTION
`tar` also using stderr for notifications if it writes output into stdout pipe

It helps to avoid several "errors", such as `tar removing leading '/' from member names`, which's not actually an error.
