### PR TITLE
cpFromPod: close writerStream syncronously

### DIFF
--- a/src/cp.ts
+++ b/src/cp.ts
@@ -41,6 +41,8 @@ export class Cp {
             null,
             false,
             async () => {
+                await new Promise((resolve) => writerStream.close(resolve));
+                
                 if (errStream.size()) {
                     throw new Error(`Error from cpFromPod - details: \n ${errStream.getContentsAsString()}`);
                 }


### PR DESCRIPTION
helps to eliminate such non-persistent error:
(node:445240) UnhandledPromiseRejectionWarning: ZlibError: zlib: unexpected end of file

caused by possibly-still-dirty writes from a previous step