### PR TITLE
Close the writestream before heading over to untar also read failure from status.

### DIFF
--- a/src/cp.ts
+++ b/src/cp.ts
@@ -87,8 +87,8 @@ export class Cp {
             errStream,
             readStream,
             false,
-            async ({status}) => {
-                if (status == 'Failure' || errStream.size()) {
+            async ({ status }) => {
+                if (status === 'Failure' || errStream.size()) {
                     throw new Error(`Error from cpToPod - details: \n ${errStream.getContentsAsString()}`);
                 }
             },

--- a/src/cp.ts
+++ b/src/cp.ts
@@ -40,8 +40,9 @@ export class Cp {
             errStream,
             null,
             false,
-            async () => {
-                if (errStream.size()) {
+            async ({ status }) => {
+                writerStream.close();
+                if (status === 'Failure' || errStream.size()) {
                     throw new Error(`Error from cpFromPod - details: \n ${errStream.getContentsAsString()}`);
                 }
                 await tar.x({

--- a/src/cp.ts
+++ b/src/cp.ts
@@ -87,8 +87,8 @@ export class Cp {
             errStream,
             readStream,
             false,
-            async () => {
-                if (errStream.size()) {
+            async ({status}) => {
+                if (status == 'Failure' || errStream.size()) {
                     throw new Error(`Error from cpToPod - details: \n ${errStream.getContentsAsString()}`);
                 }
             },


### PR DESCRIPTION
This replicates the work in #880 and #879 with some fixes, since those PRs are a good idea, but have been sitting idle.
