### PR TITLE
fix: Getter parentheses removed

### DIFF
--- a/src/gen/model/models.ts
+++ b/src/gen/model/models.ts
@@ -1593,7 +1593,7 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
-            return data.toISOString();
+            return data.toISOString;
         } else {
             if (enumsMap[type]) {
                 return data;


### PR DESCRIPTION
Date type uses `toISOString` as a getter, not as a method call. So this one caused an error.