### PR TITLE
fix: update gen commit to fix error with dubious repo

### DIFF
--- a/settings
+++ b/settings
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # kubernetes-client/gen commit to use for code generation.
-export GEN_COMMIT=82c3ff5
+export GEN_COMMIT=b32dcd6
 
 # GitHub username/organization to clone kubernetes repo from.
 export USERNAME=kubernetes


### PR DESCRIPTION
When trying to run generate, you get an error:

```
/source/openapi-generator /
fatal: detected dubious ownership in repository at '/source/openapi-generator'
To add an exception for this directory, call:

	git config --global --add safe.directory /source/openapi-generator
```
Upstream 🧵: https://github.com/kubernetes-client/gen/issues/236
Upstream Fix: https://github.com/kubernetes-client/gen/pull/237

This is a simple fix to update the commit hash and include that fix in this repo.