### PR TITLE
maintenance: added types to `KubeConfig#loadFromOptions` input

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -180,7 +180,12 @@ export class KubeConfig {
         this.currentContext = obj['current-context'];
     }
 
-    public loadFromOptions(options: any): void {
+    public loadFromOptions(options: {
+        clusters: Cluster[];
+        contexts: Context[];
+        currentContext: Context['name'];
+        users: User[];
+    }): void {
         this.clusters = options.clusters;
         this.contexts = options.contexts;
         this.users = options.users;

--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -21,7 +21,7 @@ export interface Cluster {
     readonly caData?: string;
     caFile?: string;
     readonly server: string;
-    readonly skipTLSVerify: boolean;
+    readonly skipTLSVerify?: boolean;
     readonly tlsServerName?: string;
 }
 


### PR DESCRIPTION
### Summary

This PR adds stronger types to the `KubeConfig#loadFromOptions` method which is currently accepting `any`, even though all the necessary types are already defined and available to use.