### PR TITLE
remove request usages from auth & config

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,9 +1,8 @@
 import https = require('https');
-import request = require('request');
 
 import { User } from './config_types';
 
 export interface Authenticator {
     isAuthProvider(user: User): boolean;
-    applyAuthentication(user: User, opts: request.Options | https.RequestOptions): Promise<void>;
+    applyAuthentication(user: User, opts: https.RequestOptions): Promise<void>;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -483,7 +483,7 @@ export class KubeConfig implements SecurityAuthentication {
         }
     }
 
-    private async applyAuthorizationHeader(opts: request.Options | https.RequestOptions): Promise<void> {
+    private async applyAuthorizationHeader(opts: https.RequestOptions): Promise<void> {
         const user = this.getCurrentUser();
         if (!user) {
             return;
@@ -504,7 +504,7 @@ export class KubeConfig implements SecurityAuthentication {
         }
     }
 
-    private async applyOptions(opts: request.Options | https.RequestOptions): Promise<void> {
+    private async applyOptions(opts: https.RequestOptions): Promise<void> {
         this.applyHTTPSOptions(opts);
         await this.applyAuthorizationHeader(opts);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,6 @@ import yaml = require('js-yaml');
 import net = require('net');
 import path = require('path');
 
-import request = require('request');
 import shelljs = require('shelljs');
 
 import * as api from './api';
@@ -459,7 +458,7 @@ export class KubeConfig implements SecurityAuthentication {
         return this.getContextObject(this.currentContext);
     }
 
-    private applyHTTPSOptions(opts: request.Options | https.RequestOptions): void {
+    private applyHTTPSOptions(opts: https.RequestOptions): void {
         const cluster = this.getCurrentCluster();
         const user = this.getCurrentUser();
         if (!user) {


### PR DESCRIPTION
in reference to #754, this PR removes usages of the request library (specifically the request.RequestOptions) in several interfaces to now fully rely on the https.RequestOptions instead which is compatible with fetch.

