### PR TITLE
chore: update js and typescript examples

### DIFF
--- a/FETCH_MIGRATION.md
+++ b/FETCH_MIGRATION.md
@@ -64,16 +64,16 @@ Code will be on the `master` branch.
     -   [x] cache-example
     -   [x] example
     -   [x] follow-logs
-    -   [ ] in-cluster-create-job-from-cronjob
+    -   [ ] in-cluster-create-job-from-cronjob // done but unable to test with media type problems
     -   [x] in-cluster
     -   [x] ingress
-    -   [ ] namespace
-    -   [ ] patch-example
-    -   [ ] raw-example (note: uses request lib directly, will require full fetch migration not just client param swap)
-    -   [ ] scale-deployment
+    -   [ ] namespace // done but unable to test with media type problems
+    -   [ ] patch-example 
+    -   [x] raw-example (note: uses request lib directly, will require full fetch migration not just client param swap)
+    -   [ ] scale-deployment // done but unable to test with media type problems
     -   [x] top_pods
     -   [x] top
-    -   [ ] yaml-example
+    -   [ ] yaml-example // done but unable to test with media type problems
 
 -   [ ] Fix TypeScript examples and validate their param signatures (due to new api)
 
@@ -81,11 +81,11 @@ Code will be on the `master` branch.
     -   [ ] attach-example
     -   [ ] cp-example
     -   [ ] exec-example
-    -   [ ] informer-with-label-selector
-    -   [ ] informer
+    -   [ ] informer-with-label-selector // done but unable to test with media type problems
+    -   [x] informer
     -   [ ] port-forward
-    -   [ ] example
-    -   [ ] watch-example
+    -   [x] example
+    -   [x] watch-example
 
 -   [ ] Update docs
     -   [ ] Update README examples

--- a/examples/in-cluster-create-job-from-cronjob.js
+++ b/examples/in-cluster-create-job-from-cronjob.js
@@ -1,12 +1,13 @@
-const k8s = require('@kubernetes/client-node');
+// in a real program use require('@kubernetes/client-node')
+const k8s = require('../dist/index');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromCluster();
 
 const batchV1Api = kc.makeApiClient(k8s.BatchV1Api);
 const batchV1beta1Api = kc.makeApiClient(k8s.BatchV1beta1Api);
-const cronJobName = 'myCronJob';
-const jobName = 'myJob';
+const cronJobName = 'cronjob';
+const jobName = 'myjob';
 
 const job = new k8s.V1Job();
 const metadata = new k8s.V1ObjectMeta();
@@ -18,12 +19,14 @@ metadata.annotations = {
 };
 job.metadata = metadata;
 
-batchV1beta1Api.readNamespacedCronJob(cronJobName, 'default')
+batchV1beta1Api
+    .readNamespacedCronJob({ name: cronJobName, namespace: 'default' })
     .then((cronJobRes) => {
-        job.spec = cronJobRes.body.spec.jobTemplate.spec;
-        batchV1Api.createNamespacedJob('default', job)
+        job.spec = cronJobRes?.spec?.jobTemplate.spec;
+        batchV1Api
+            .createNamespacedJob({ namespace: 'default', body: job })
             .then((res) => {
-                console.log(res.body);
+                console.log(res);
             })
             .catch((err) => {
                 console.log(err);

--- a/examples/namespace.js
+++ b/examples/namespace.js
@@ -1,4 +1,5 @@
-const k8s = require('@kubernetes/client-node');
+// in a real program use require('@kubernetes/client-node')
+const k8s = require('../dist/index');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -6,23 +7,21 @@ kc.loadFromDefault();
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
 var namespace = {
-  metadata: {
-    name: 'test'
-  }
+    metadata: {
+        name: 'test',
+    },
 };
 
-k8sApi.createNamespace(namespace).then(
-  (response) => {
-    console.log('Created namespace');
-    console.log(response);
-    k8sApi.readNamespace(namespace.metadata.name).then(
-      (response) => {
+k8sApi.createNamespace({ body: namespace }).then(
+    (response) => {
+        console.log('Created namespace');
         console.log(response);
-	k8sApi.deleteNamespace(
-          namespace.metadata.name, {} /* delete options */);
-      });
-  },
-  (err) => {
-    console.log('Error!: ' + err);
-  }
+        k8sApi.readNamespace({ name: namespace.metadata.name }).then((response) => {
+            console.log(response);
+            k8sApi.deleteNamespace({ name: namespace.metadata.name });
+        });
+    },
+    (err) => {
+        console.log('Error!: ' + err);
+    },
 );

--- a/examples/patch-example.js
+++ b/examples/patch-example.js
@@ -1,23 +1,33 @@
-const k8s = require('@kubernetes/client-node');
+// in a real program use require('@kubernetes/client-node')
+const k8s = require('../dist/index');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-k8sApi.listNamespacedPod('default')
-    .then((res) => {
-        const patch = [
-            {
-                "op": "replace",
-                "path":"/metadata/labels",
-                "value": {
-                    "foo": "bar"
-                }
-            }
-        ];
-        const options = { "headers": { "Content-type": k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH}};
-        k8sApi.patchNamespacedPod(res.body.items[0].metadata.name, 'default', patch, undefined, undefined, undefined, undefined, options)
-            .then(() => { console.log("Patched.")})
-            .catch((err) => { console.log("Error: "); console.log(err)});
-    });
+k8sApi.listNamespacedPod({ namespace: 'default' }).then((res) => {
+    const patch = [
+        {
+            op: 'replace',
+            path: '/metadata/labels',
+            value: {
+                foo: 'bar',
+            },
+        },
+    ];
+    // TODO this method of passing the content type will change when we figure out a way to properly do this
+    const options = { headers: { 'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
+    k8sApi
+        .patchNamespacedPod(
+            { name: res?.items?.[0].metadata?.name ?? '', namespace: 'default', body: patch },
+            options,
+        )
+        .then(() => {
+            console.log('Patched.');
+        })
+        .catch((err) => {
+            console.log('Error: ');
+            console.log(err);
+        });
+});

--- a/examples/raw-example.js
+++ b/examples/raw-example.js
@@ -1,20 +1,37 @@
-const k8s = require('@kubernetes/client-node');
-const request = require('request');
+// in a real program use require('@kubernetes/client-node')
+const k8s = require('../dist/index');
+const fetch = require('node-fetch');
+const https = require('https');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
-const opts = {};
-kc.applyToRequest(opts);
+const currentUser = kc.getCurrentUser();
+const currentCluster = kc.getCurrentCluster();
 
-request.get(`${kc.getCurrentCluster().server}/api/v1/namespaces/default/pods`, opts,
-    (error, response, body) => {
-        if (error) {
-            console.log(`error: ${error}`);
-        }
-        if (response) {
-            console.log(`statusCode: ${response.statusCode}`);
-        }
+const agent = new https.Agent({
+    ca: Buffer.from(currentCluster?.caData ?? '', 'base64').toString('utf8'),
+    cert: Buffer.from(currentUser?.certData ?? '', 'base64').toString('utf8'),
+    keepAlive: true,
+    key: Buffer.from(currentUser?.keyData ?? '', 'base64').toString('utf8'),
+});
+
+const opts = {
+    headers: {},
+    agent: agent,
+};
+
+kc.applyToHTTPSOptions(opts);
+
+const url = `${kc?.getCurrentCluster()?.server}/api/v1/namespaces/default/pods`;
+fetch(url, opts)
+    .then((response) => {
+        console.log(`statusCode: ${response.status}`);
+        return response.text();
+    })
+    .then((body) => {
         console.log(`body: ${body}`);
-  });
-
+    })
+    .catch((error) => {
+        console.log(`error: ${error}`);
+    });

--- a/examples/scale-deployment.js
+++ b/examples/scale-deployment.js
@@ -1,4 +1,5 @@
-const k8s = require('@kubernetes/client-node');
+// in a real program use require('@kubernetes/client-node')
+const k8s = require('../dist/index');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -9,16 +10,31 @@ const targetNamespaceName = 'default';
 const targetDeploymentName = 'docker-test-deployment';
 const numberOfTargetReplicas = 3;
 
-async function scale(namespace, name, replicas) {
-  // find the particular deployment
-  const res = await k8sApi.readNamespacedDeployment(name, namespace);
-  let deployment = res.body;
+async function scale(deploymentNamespace, deploymentName, replicas) {
+    // find the particular deployment
+    const deployment = await k8sApi.readNamespacedDeployment({
+        name: deploymentName,
+        namespace: deploymentNamespace,
+    });
 
-  // edit
-  deployment.spec.replicas = replicas;
+    if (!deployment || !deployment.spec) {
+        throw new Error(`Deployment ${deploymentName} not found in namespace ${deploymentNamespace}`);
+    }
+    // edit
+    const newDeployment = {
+        ...deployment,
+        spec: {
+            ...deployment.spec,
+            replicas,
+        },
+    };
 
-  // replace
-  await k8sApi.replaceNamespacedDeployment(name, namespace, deployment);
+    // replace
+    await k8sApi.replaceNamespacedDeployment({
+        name: deploymentName,
+        namespace: deploymentNamespace,
+        body: newDeployment,
+    });
 }
 
 scale(targetNamespaceName, targetDeploymentName, numberOfTargetReplicas);

--- a/examples/typescript/informer/informer.ts
+++ b/examples/typescript/informer/informer.ts
@@ -1,24 +1,33 @@
 // tslint:disable:no-console
-import * as k8s from '@kubernetes/client-node';
+
+// in a real program use require('@kubernetes/client-node')
+import * as k8s from '../../../dist/index';
 
 const kc = new k8s.KubeConfig();
+
 kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-const listFn = () => k8sApi.listNamespacedPod('default');
+const listFn = () => k8sApi.listNamespacedPod({ namespace: 'default' });
 
 const informer = k8s.makeInformer(kc, '/api/v1/namespaces/default/pods', listFn);
 
-informer.on('add', (obj: k8s.V1Pod) => { console.log(`Added: ${obj.metadata!.name}`); });
-informer.on('update', (obj: k8s.V1Pod) => { console.log(`Updated: ${obj.metadata!.name}`); });
-informer.on('delete', (obj: k8s.V1Pod) => { console.log(`Deleted: ${obj.metadata!.name}`); });
+informer.on('add', (obj: k8s.V1Pod) => {
+    console.log(`Added: ${obj.metadata!.name}`);
+});
+informer.on('update', (obj: k8s.V1Pod) => {
+    console.log(`Updated: ${obj.metadata!.name}`);
+});
+informer.on('delete', (obj: k8s.V1Pod) => {
+    console.log(`Deleted: ${obj.metadata!.name}`);
+});
 informer.on('error', (err: k8s.V1Pod) => {
-  console.error(err);
-  // Restart informer after 5sec
-  setTimeout(() => {
-    informer.start();
-  }, 5000);
+    console.error(err);
+    // Restart informer after 5sec
+    setTimeout(() => {
+        informer.start();
+    }, 5000);
 });
 
 informer.start();

--- a/examples/typescript/simple/example.ts
+++ b/examples/typescript/simple/example.ts
@@ -1,15 +1,15 @@
-import k8s = require('@kubernetes/client-node');
+// in a real program use require('@kubernetes/client-node')
+import * as k8s from '../../../dist/index';
+
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-k8sApi.listNamespacedPod('default')
-    .then((res) => {
-        // tslint:disable-next-line:no-console
-        console.log(res.body);
-    });
+k8sApi.listNamespacedPod({ namespace: 'default' }).then((res) => {
+    // tslint:disable-next-line:no-console
+    console.log(res.body);
+});
 
 // Example of instantiating a Pod object.
-const pod = {
-} as k8s.V1Pod;
+const pod = {} as k8s.V1Pod;

--- a/examples/typescript/watch/watch-example.ts
+++ b/examples/typescript/watch/watch-example.ts
@@ -1,41 +1,47 @@
-import * as k8s from '@kubernetes/client-node';
+// in a real program use require('@kubernetes/client-node')
+import * as k8s from '../../../dist/index';
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const watch = new k8s.Watch(kc);
-watch.watch('/api/v1/namespaces',
-    // optional query parameters can go here.
-    {
-        allowWatchBookmarks: true,
-    },
-    // callback is called for each received object.
-    (type, apiObj, watchObj) => {
-        if (type === 'ADDED') {
+watch
+    .watch(
+        '/api/v1/namespaces',
+        // optional query parameters can go here.
+        {
+            allowWatchBookmarks: true,
+        },
+        // callback is called for each received object.
+        (type, apiObj, watchObj) => {
+            if (type === 'ADDED') {
+                // tslint:disable-next-line:no-console
+                console.log('new object:');
+            } else if (type === 'MODIFIED') {
+                // tslint:disable-next-line:no-console
+                console.log('changed object:');
+            } else if (type === 'DELETED') {
+                // tslint:disable-next-line:no-console
+                console.log('deleted object:');
+            } else if (type === 'BOOKMARK') {
+                // tslint:disable-next-line:no-console
+                console.log(`bookmark: ${watchObj.metadata.resourceVersion}`);
+            } else {
+                // tslint:disable-next-line:no-console
+                console.log('unknown type: ' + type);
+            }
             // tslint:disable-next-line:no-console
-            console.log('new object:');
-        } else if (type === 'MODIFIED') {
+            console.log(apiObj);
+        },
+        // done callback is called if the watch terminates normally
+        (err) => {
             // tslint:disable-next-line:no-console
-            console.log('changed object:');
-        } else if (type === 'DELETED') {
-            // tslint:disable-next-line:no-console
-            console.log('deleted object:');
-        } else if (type === 'BOOKMARK') {
-            // tslint:disable-next-line:no-console
-            console.log(`bookmark: ${watchObj.metadata.resourceVersion}`);
-        } else {
-            // tslint:disable-next-line:no-console
-            console.log('unknown type: ' + type);
-        }
-        // tslint:disable-next-line:no-console
-        console.log(apiObj);
-    },
-    // done callback is called if the watch terminates normally
-    (err) => {
-        // tslint:disable-next-line:no-console
-        console.log(err);
-    })
-.then((req) => {
-    // watch returns a request object which you can use to abort the watch.
-    setTimeout(() => { req.abort(); }, 10 * 1000);
-});
+            console.log(err);
+        },
+    )
+    .then((req) => {
+        // watch returns a request object which you can use to abort the watch.
+        setTimeout(() => {
+            req.abort();
+        }, 10 * 1000);
+    });

--- a/examples/yaml-example.js
+++ b/examples/yaml-example.js
@@ -1,4 +1,5 @@
-const k8s = require('@kubernetes/client-node');
+// in a real program use require('@kubernetes/client-node')
+const k8s = require('../dist/index');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -6,25 +7,23 @@ kc.loadFromDefault();
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
 const yamlString = k8s.dumpYaml({
-  metadata: {
-    name: 'test'
-  }
+    metadata: {
+        name: 'test',
+    },
 });
 
 const yamlNamespace = k8s.loadYaml(yamlString);
 
-k8sApi.createNamespace(yamlNamespace).then(
-  (response) => {
-    console.log('Created namespace');
-    console.log(response);
-    k8sApi.readNamespace(yamlNamespace.metadata.name).then(
-      (response) => {
+k8sApi.createNamespace({ body: yamlNamespace }).then(
+    (response) => {
+        console.log('Created namespace');
         console.log(response);
-        k8sApi.deleteNamespace(
-          yamlNamespace.metadata.name, {} /* delete options */);
-      });
-  },
-  (err) => {
-    console.log('Error!: ' + err);
-  }
+        k8sApi.readNamespace({ name: yamlNamespace.metadata.name }).then((response) => {
+            console.log(response);
+            k8sApi.deleteNamespace({ name: yamlNamespace.metadata.name }, {} /* delete options */);
+        });
+    },
+    (err) => {
+        console.log('Error!: ' + err);
+    },
 );


### PR DESCRIPTION
This is part two of updating examples to node-fetch. A lot of these examples do not work do to this issue (https://github.com/kubernetes-client/javascript/issues/893) but I have updated the syntax to match what we need with fetch. Other examples do work. Let me know if you would like me to separate these out. 

Right now I just put a note in the `FETCH_MIGRATION` file. If you have another idea to best handle this then let me know and I will update.

