### PR TITLE
[release-1.x] Fix media type error

### DIFF
--- a/src/gen/models/ObjectSerializer.ts
+++ b/src/gen/models/ObjectSerializer.ts
@@ -1052,27 +1052,27 @@ import { VersionInfo } from '../models/VersionInfo';
 
 /* tslint:disable:no-unused-variable */
 let primitives = [
-                    "string",
-                    "boolean",
-                    "double",
-                    "integer",
-                    "long",
-                    "float",
-                    "number",
-                    "any"
-                 ];
+    "string",
+    "boolean",
+    "double",
+    "integer",
+    "long",
+    "float",
+    "number",
+    "any"
+];
 
 const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
+    "application/json": Infinity,
+    "application/octet-stream": 0,
+    "application/x-www-form-urlencoded": 0
 }
 
 
 let enumsMap: Set<string> = new Set<string>([
 ]);
 
-let typeMap: {[index: string]: any} = {
+let typeMap: { [index: string]: any } = {
     "AdmissionregistrationV1ServiceReference": AdmissionregistrationV1ServiceReference,
     "AdmissionregistrationV1WebhookClientConfig": AdmissionregistrationV1WebhookClientConfig,
     "ApiextensionsV1ServiceReference": ApiextensionsV1ServiceReference,
@@ -1624,7 +1624,7 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    if (typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
@@ -1652,7 +1652,7 @@ export class ObjectSerializer {
             return transformedData;
         } else if (type === "Date") {
             if (format == "date") {
-                let month = data.getMonth()+1
+                let month = data.getMonth() + 1
                 month = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
                 day = day < 10 ? "0" + day.toString() : day.toString();
@@ -1674,7 +1674,7 @@ export class ObjectSerializer {
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();
-            let instance: {[index: string]: any} = {};
+            let instance: { [index: string]: any } = {};
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
                 instance[attributeType.baseName] = ObjectSerializer.serialize(data[attributeType.name], attributeType.type, attributeType.format);
@@ -1744,7 +1744,7 @@ export class ObjectSerializer {
      */
     public static getPreferredMediaType(mediaTypes: Array<string>): string {
         /** According to OAS 3 we should default to json */
-        if (!mediaTypes) {
+        if (!mediaTypes || mediaTypes.length === 0) {
             return "application/json";
         }
 


### PR DESCRIPTION
Whenever calling createNamespacedSecret or deleteNamespacedSecret, there is an error occurs like the following:
```
Error: None of the given media types are supported: 
<Stack trace>
```
The error shows that there are no `mediaTypes` to the `getPreferredMediaType` function. After some digging, turns out that there is a condition that wasn't taking into account the fact that the array can be empty (not undefined) which in this case should default to `application/json`.