### PR TITLE
Change how we use readFileSync to renable mockfs to work.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -142,7 +142,7 @@ export class KubeConfig implements SecurityAuthentication {
 
     public loadFromFile(file: string, opts?: Partial<ConfigOptions>): void {
         const rootDirectory = path.dirname(file);
-        this.loadFromString(fs.readFileSync(file, 'utf8'), opts);
+        this.loadFromString(fs.readFileSync(file).toString('utf-8'), opts);
         this.makePathsAbsolute(rootDirectory);
     }
 
@@ -323,7 +323,7 @@ export class KubeConfig implements SecurityAuthentication {
         const namespaceFile = `${pathPrefix}${SERVICEACCOUNT_NAMESPACE_PATH}`;
         let namespace: string | undefined;
         if (fileExists(namespaceFile)) {
-            namespace = fs.readFileSync(namespaceFile, 'utf8');
+            namespace = fs.readFileSync(namespaceFile).toString('utf-8');
         }
         this.contexts = [
             {


### PR DESCRIPTION
Nodejs 20.5.0 introduced an optimization for utf-8 files:
https://github.com/nodejs/node/pull/48658

This broke mock-fs which we use for testing:
https://github.com/tschaub/mock-fs/issues/377

This slightly changes how we read files to work around this issue. We won't get the performance improvements from the node changes, but given that config loading isn't really hot path, I don't think it matters.

We should consider reverting if/when mock-fs fixes this, but for now, this fixes CI/CD so we can merge other PRs.

cc @mstruebing 