### PR TITLE
chore: add kubectl equivalent examples

### DIFF
--- a/examples/kubectl/equivalents/namespace-create-yaml.js
+++ b/examples/kubectl/equivalents/namespace-create-yaml.js
@@ -1,0 +1,24 @@
+const k8s = require('@kubernetes/client-node');
+const fs = require('fs');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl apply -f namespace.yml`
+ * You can find the sample namespace.yml file in the examples/resources folder
+ */
+
+const namespaceCreateYaml = async () => {
+    try {
+        const namespaceYaml = k8s.loadYaml(fs.readFileSync('../../resources/namespace.yml'));
+        const createdNamespace = await k8sApi.createNamespace(namespaceYaml);
+        console.log('New namespace created: ', createdNamespace.body);
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+namespaceCreateYaml();

--- a/examples/kubectl/equivalents/namespace-create.js
+++ b/examples/kubectl/equivalents/namespace-create.js
@@ -1,0 +1,26 @@
+const k8s = require('@kubernetes/client-node');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl create namespace test`
+ */
+
+const namespaceCreate = async () => {
+    try {
+        const namespace = {
+            metadata: {
+                name: 'test',
+            },
+        };
+        const createdNamespace = await k8sApi.createNamespace(namespace);
+        console.log('New namespace created: ', createdNamespace.body);
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+namespaceCreate();

--- a/examples/kubectl/equivalents/namespace-list.js
+++ b/examples/kubectl/equivalents/namespace-list.js
@@ -1,0 +1,21 @@
+const k8s = require('@kubernetes/client-node');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl get ns`
+ */
+
+const namespaceList = async () => {
+    try {
+        const namespaces = await k8sApi.listNamespace();
+        namespaces.body.items.map(namespace => console.log(namespace.metadata.name))
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+namespaceList();

--- a/examples/kubectl/equivalents/pod-create.js
+++ b/examples/kubectl/equivalents/pod-create.js
@@ -1,0 +1,34 @@
+const k8s = require('@kubernetes/client-node');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl run demo-pod --image=nginx --namespace=default`
+ */
+
+const podCreate = async () => {
+    const pod = {
+        metadata:{
+            name: "demo-pod"
+        },
+        spec:{
+            containers:[{
+                name: "nginx-container",
+                image:"nginx"
+            }]
+        }
+    }
+    try{
+        const createdPod = await k8sApi.createNamespacedPod('default', pod)
+        console.log("Created pod: " + createdPod.body)
+
+    }
+    catch(err){
+        console.error(err);
+    }
+};
+
+podCreate();

--- a/examples/kubectl/equivalents/pod-filter-by-namespace.js
+++ b/examples/kubectl/equivalents/pod-filter-by-namespace.js
@@ -1,0 +1,21 @@
+const k8s = require('@kubernetes/client-node');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl get pods --namespace=default`
+ */
+
+const podFilterByNamespace = async () => {
+    try {
+        const pods = await k8sApi.listNamespacedPod('default');
+        pods.body.items.map(pod => console.log(pod.metadata.name))
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+podFilterByNamespace();

--- a/examples/kubectl/equivalents/resourceQuota-create.js
+++ b/examples/kubectl/equivalents/resourceQuota-create.js
@@ -1,0 +1,32 @@
+const k8s = require('@kubernetes/client-node');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl create resourcequota my-quota --hard=pods=3`
+ */
+
+const resourceQuotaCreate = async () => {
+    try{
+        const quota = {
+            metadata:{
+                name: "my-quota"
+            },
+            spec:{
+                hard:{
+                    pods:"3"
+                }
+            }
+        }
+        const createdQuota = await k8sApi.createNamespacedResourceQuota("default", quota);
+        console.log("Created quota: " + createdQuota.body)
+    }
+    catch(err){
+        console.error(err);
+    }
+};
+
+resourceQuotaCreate();

--- a/examples/kubectl/equivalents/resourceQuota-list.js
+++ b/examples/kubectl/equivalents/resourceQuota-list.js
@@ -1,0 +1,22 @@
+const k8s = require('@kubernetes/client-node');
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * This sample code is Javascript equivalent to `kubectl get resourcequotas --all-namespaces`
+ */
+
+const resourceQuotaList = async () => {
+    try{
+        const resourceQuotas = await k8sApi.listResourceQuotaForAllNamespaces();
+        resourceQuotas.body.items.map(quota => console.log(quota.metadata.name))
+    }
+    catch(err){
+        console.error(err);
+    }
+};
+
+resourceQuotaList();

--- a/examples/resources/namespace.yml
+++ b/examples/resources/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test


### PR DESCRIPTION
Related to #1253 
Created a `kubectl/equivalents` folder inside examples. Each file corresponds to the relevant kubectl command making it easier for users to understand the usage of the client. Makes it more readable and maintainable.

Current files added:
- Create namespace
- Create Namespace from yaml
- Create Namespaced pod
- List namespaces
- List Pods
- Create Resource quotas
- List all Resource quotas

... more to be added