### PR TITLE
FEAT: Adding support for multiple client

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,7 +39,7 @@ function fileExists(filepath: string): boolean {
 }
 
 export class KubeConfig {
-    private static authenticators: Authenticator[] = [
+    private authenticators: Authenticator[] = [
         new AzureAuth(),
         new GoogleCloudPlatformAuth(),
         new ExecAuth(),
@@ -450,7 +450,7 @@ export class KubeConfig {
         if (!user) {
             return;
         }
-        const authenticator = KubeConfig.authenticators.find((elt: Authenticator) => {
+        const authenticator = this.authenticators.find((elt: Authenticator) => {
             return elt.isAuthProvider(user);
         });
 

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1169,7 +1169,7 @@ describe('KubeConfig', () => {
             // TODO: inject the exec command here?
             const opts = {} as requestlib.Options;
             await config.applyToRequest(opts);
-            let execAuthenticator = (KubeConfig as any).authenticators.find(
+            let execAuthenticator = (config as any).authenticators.find(
                 (authenticator) => authenticator instanceof ExecAuth,
             );
             expect(execAuthenticator.tokenCache['exec']).to.deep.equal(JSON.parse(responseStr));


### PR DESCRIPTION
I have found that while creating multiple client with different access in single application.
Both of the client overlap the credentials and start returning the 403 error. Whereas the client created with proper credentials.