### PR TITLE
docs: exec example

### DIFF
--- a/examples/typescript/exec/exec-example.ts
+++ b/examples/typescript/exec/exec-example.ts
@@ -1,8 +1,6 @@
 import * as k8s from '@kubernetes/client-node';
 import * as stream from 'stream';
 
-const command = process.argv[2];
-
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
@@ -11,7 +9,7 @@ exec.exec(
     'default',
     'nginx-4217019353-9gl4s',
     'nginx',
-    command,
+    ["ls, "-al", "."],
     process.stdout as stream.Writable,
     process.stderr as stream.Writable,
     process.stdin as stream.Readable,

--- a/examples/typescript/exec/exec-example.ts
+++ b/examples/typescript/exec/exec-example.ts
@@ -9,7 +9,7 @@ exec.exec(
     'default',
     'nginx-4217019353-9gl4s',
     'nginx',
-    ["ls, "-al", "."],
+    ['ls, '-al', '.'],
     process.stdout as stream.Writable,
     process.stderr as stream.Writable,
     process.stdin as stream.Readable,


### PR DESCRIPTION
# Problem

Cmd+arg was not clearly recorded in the examples, leading me to try zany things, like piping my cmds via stdin, but then the websocket closing prematurely

# Solution

Make the default example clear that string[] is a permissible input for a req/res lifecycle of exec, despite being over a ws