### PR TITLE
feat: `kubectl` class for directly calling kubectl equivalent commands

### DIFF
--- a/src/extended/kubectl/kubectl-get.ts
+++ b/src/extended/kubectl/kubectl-get.ts
@@ -1,0 +1,9 @@
+import { KubernetesObject } from '../../types';
+
+export class kubectlGet<ApiType extends KubernetesObject> {
+    private apiTypeClass: new () => ApiType;
+
+    constructor(apiTypeClass: new () => ApiType) {
+        this.apiTypeClass = apiTypeClass;
+    }
+}

--- a/src/extended/kubectl/kubectl-get.ts
+++ b/src/extended/kubectl/kubectl-get.ts
@@ -1,9 +1,30 @@
-import { KubernetesObject } from '../../types';
+import { KubernetesObject, KubernetesListObject } from '../../types';
+import { genericKubernetesApi } from '../util/generic/generic-kubernetes-api';
+import { kubectl } from './kubectl';
 
-export class kubectlGet<ApiType extends KubernetesObject> {
+export class kubectlGet<ApiType extends KubernetesObject> extends kubectl.ApiClientBuilder {
     private apiTypeClass: new () => ApiType;
 
     constructor(apiTypeClass: new () => ApiType) {
+        super();
         this.apiTypeClass = apiTypeClass;
+    }
+
+    public execute() {
+        // refreshDiscovery();
+
+        let api: genericKubernetesApi<ApiType, KubernetesListObject<ApiType>> = this.getGenericApi(
+            this.apiTypeClass,
+        );
+        try {
+            // if (isNamespaced()) {
+            // return api.list(namespace, listOptions).throwsApiException().getObject().getItems();
+            // } else {
+            // return api.list(listOptions).throwsApiException().getObject().getItems();
+            // }
+        } catch (e) {
+            // throw new KubectlException(e);
+            console.error(e);
+        }
     }
 }

--- a/src/extended/kubectl/kubectl.ts
+++ b/src/extended/kubectl/kubectl.ts
@@ -1,0 +1,14 @@
+import { KubernetesObject } from '../../types';
+import { kubectlGet } from './kubectl-get';
+
+/**
+ * Kubectl provides a set of helper functions that has the same functionalities as corresponding
+ * kubectl commands.
+ */
+
+class kubectl {
+    /** Equivalent for `kubectl get` */
+    static get<ApiType extends KubernetesObject>(apiTypeClass: new () => ApiType): kubectlGet<ApiType> {
+        return new kubectlGet(apiTypeClass);
+    }
+}

--- a/src/extended/kubectl/kubectl.ts
+++ b/src/extended/kubectl/kubectl.ts
@@ -1,14 +1,80 @@
-import { KubernetesObject } from '../../types';
+import { KubernetesObject, KubernetesListObject } from '../../types';
 import { kubectlGet } from './kubectl-get';
+import { genericKubernetesApi } from '../util/generic/generic-kubernetes-api';
 
 /**
  * Kubectl provides a set of helper functions that has the same functionalities as corresponding
  * kubectl commands.
  */
 
-class kubectl {
+export class kubectl {
     /** Equivalent for `kubectl get` */
     static get<ApiType extends KubernetesObject>(apiTypeClass: new () => ApiType): kubectlGet<ApiType> {
         return new kubectlGet(apiTypeClass);
     }
+
+    static ApiClientBuilder = class {
+        apiClient: any;
+        skipDiscovery: boolean;
+
+        constructor() {
+            this.apiClient = Configuration.getDefaultApiClient();
+            this.skipDiscovery = false;
+        }
+
+        async refreshDiscovery() {
+            if (this.skipDiscovery) {
+                return;
+            }
+
+            try {
+                await ModelMapper.refresh(new Discovery(this.apiClient));
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
+        getGenericApi<ApiType extends KubernetesObject>(apiTypeClass: new () => ApiType) {
+            const apiListTypeClassName = 'list' + apiTypeClass.name;
+
+            try {
+                const apiTypeListClass = require(apiListTypeClassName);
+                return this.getGenericApiWithType(apiTypeClass, apiTypeListClass);
+            } catch (e) {
+                throw new Error(`No such api list type class ${apiListTypeClassName}`);
+            }
+        }
+
+        getGenericApiWithType<
+            ApiType extends KubernetesObject,
+            ApiListType extends KubernetesListObject<ApiType>,
+        >(
+            apiTypeClass: new () => ApiType,
+            apiListTypeClass: new () => ApiListType,
+        ): genericKubernetesApi<ApiType, ApiListType> {
+            const groupVersionResource = ModelMapper.getGroupVersionResourceByClass(apiTypeClass);
+            if (!groupVersionResource) {
+                throw new Error(`Unexpected unknown resource type: ${apiTypeClass}`);
+            }
+            const api = new genericKubernetesApi(
+                apiTypeClass,
+                apiListTypeClass,
+                groupVersionResource.group,
+                groupVersionResource.version,
+                groupVersionResource.resource,
+                this.apiClient,
+            );
+            return api;
+        }
+
+        // apiClient(apiClient) {
+        //     this.apiClient = apiClient;
+        //     return this;
+        // }
+
+        // skipDiscovery() {
+        //     this.skipDiscovery = true;
+        //     return this;
+        // }
+    };
 }

--- a/src/extended/util/generic/generic-kubernetes-api.ts
+++ b/src/extended/util/generic/generic-kubernetes-api.ts
@@ -1,0 +1,54 @@
+import { KubernetesObject, KubernetesListObject } from '../../../types';
+import { CustomObjectsApi } from '../../../api';
+import { Request } from 'request';
+// import { request } from 'http';
+import request from 'request';
+
+export class genericKubernetesApi<
+    ApiType extends KubernetesObject,
+    ApiListType extends KubernetesListObject<ApiType>,
+> {
+    private apiTypeClass!: new () => ApiType;
+    private apiListTypeClass!: new () => ApiListType;
+    private apiGroup!: String;
+    private apiVersion!: String;
+    private resourcePlural!: String;
+    private apiClient!: any;
+    // private customObjectsApi: CustomObjectsApi;
+
+    /**
+     * Instantiates a new Generic kubernetes api.
+     *
+     * @param apiTypeClass the api type class, e.g. V1Job.class
+     * @param apiListTypeClass the api list type class e.g. V1JobList.class
+     * @param apiGroup the api group
+     * @param apiVersion the api version
+     * @param resourcePlural the resource plural, e.g. "jobs"
+     * @param apiClient the api client
+     */
+    constructor(
+        apiTypeClass: new () => ApiType,
+        apiListTypeClass: new () => ApiListType,
+        apiGroup: String,
+        apiVersion: String,
+        resourcePlural: String,
+        apiClient: any,
+    ) {
+        this.apiTypeClass = apiTypeClass;
+        this.apiListTypeClass = apiListTypeClass;
+        this.apiGroup = apiGroup;
+        this.apiVersion = apiVersion;
+        this.resourcePlural = resourcePlural;
+        // this.customObjectsApi = new CustomObjectsApi(apiClient);
+        this.apiClient = apiClient;
+    }
+
+    /**
+     * List kubernetes api response cluster-scoped.
+     *
+     * @return the kubernetes api response
+     */
+    public list() {
+        return request.get(this.apiClient);
+    }
+}


### PR DESCRIPTION
WIP
- need to work on generic K8s api implementation
- currently focusing on just the `get` method that should invoke the list method of `genericKubernetesApi` for all `apiType` (pods, namespaces, etc..)
- will add necessary tests once implemented

### Notes for reviewers
I have created a draft PR for ease of reviewing....would make necessary changes as per feedback :)
This will be implemented in a similar way to the java client as discussed here #1254   