### PR TITLE
Fix spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const main = async () => {
         console.log('New namespace created: ', createNamespaceRes.body);
 
         const readNamespaceRes = await k8sApi.readNamespace(namespace.metadata.name);
-        console.log('Namespcace: ', readNamespaceRes.body);
+        console.log('Namespace: ', readNamespaceRes.body);
 
         await k8sApi.deleteNamespace(namespace.metadata.name, {});
     } catch (err) {


### PR DESCRIPTION
Spelling Change from `Namespcace` to `Namespace`.