### PR TITLE
Update Kubernetes Version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ release, we will increment the minor version whenever we update the minor Kubern
 
 Generally speaking newer clients will work with older Kubernetes, but compatability isn't 100% guaranteed.
 
-| client version | older versions | 1.20 | 1.21 | 1.22 | 1.23 | 1.24 | 1.25 | 1.26 | 1.27 | 1.20 |
+| client version | older versions | 1.20 | 1.21 | 1.22 | 1.23 | 1.24 | 1.25 | 1.26 | 1.27 | 1.28 |
 |----------------|----------------|------|------|------|------|-------|------|-----|------|------|
 |  0.14.x        |       -        |  ✓   |  x   |  x   |  x   |  x   |  x  |  x  |  x  |  x  |
 |  0.15.x        |       -        |  +   |  ✓   |  x   |  x   |  x   |  x  |  x  |  x  |  x  |


### PR DESCRIPTION
The newest version says `1.20` when you probably mean to say `1.28`.