### PR TITLE
ci: dont annotate the git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           git config --global user.name 'Github Bot'
           git config --global user.email '<>'
-          git tag -a ${{ github.events.inputs.version }}
+          git tag ${{ github.events.inputs.version }}
       - name: Push tag
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |


### PR DESCRIPTION
We kind of have two options here, provide an additional message
for the `-a` tag or add an addtional message with the `-m` argument.

From the help message:
```
-a, --annotate        annotated tag, needs a message
```

I opted for removing it but if you feel like we should rather add a message let me know
