### PR TITLE
chore: run npm audit fix to update vulnerabile package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       - run: node version-check.js
       - run: npm ci
       - run: npm test
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
       - run: npm run lint
       - run: npm audit --audit-level=critical
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,12 +56,16 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
@@ -94,55 +98,53 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@babel/core/node_modules/@babel/code-frame": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "node_modules/@babel/core/node_modules/@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-            }
-        },
         "node_modules/@babel/generator": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-            "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.12.11",
-                "jsesc": "^2.5.1",
-                "source-map": "^0.5.0"
+                "@babel/types": "^7.23.0",
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
+                "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-environment-visitor": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-            "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-get-function-arity": "^7.12.10",
-                "@babel/template": "^7.12.7",
-                "@babel/types": "^7.12.11"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-            "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+        "node_modules/@babel/helper-hoist-variables": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.12.10"
+                "@babel/types": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
@@ -211,19 +213,34 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-            "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.12.11"
+                "@babel/types": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-            "dev": true
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
         },
         "node_modules/@babel/helpers": {
             "version": "7.12.5",
@@ -237,20 +254,23 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
             "dev": true,
             "dependencies": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-            "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -260,82 +280,52 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.12.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.12.7",
-                "@babel/types": "^7.12.7"
-            }
-        },
-        "node_modules/@babel/template/node_modules/@babel/code-frame": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "node_modules/@babel/template/node_modules/@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-            "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.12.11",
-                "@babel/generator": "^7.12.11",
-                "@babel/helper-function-name": "^7.12.11",
-                "@babel/helper-split-export-declaration": "^7.12.11",
-                "@babel/parser": "^7.12.11",
-                "@babel/types": "^7.12.12",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.19"
-            }
-        },
-        "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "node_modules/@babel/traverse/node_modules/@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-            "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.12.11",
-                "lodash": "^4.17.19",
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -516,6 +506,54 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -868,9 +906,9 @@
             }
         },
         "node_modules/chalk": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-            "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -1161,15 +1199,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/esutils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/fill-range": {
@@ -1627,9 +1656,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -2075,9 +2104,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -2914,9 +2943,9 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -3749,12 +3778,13 @@
     },
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
             }
         },
         "@babel/core": {
@@ -3778,59 +3808,43 @@
                 "lodash": "^4.17.19",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.10.4"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.4",
-                        "chalk": "^2.0.0",
-                        "js-tokens": "^4.0.0"
-                    }
-                }
             }
         },
         "@babel/generator": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-            "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.12.11",
-                "jsesc": "^2.5.1",
-                "source-map": "^0.5.0"
+                "@babel/types": "^7.23.0",
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
+                "jsesc": "^2.5.1"
             }
+        },
+        "@babel/helper-environment-visitor": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "dev": true
         },
         "@babel/helper-function-name": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-            "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.12.10",
-                "@babel/template": "^7.12.7",
-                "@babel/types": "^7.12.11"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             }
         },
-        "@babel/helper-get-function-arity": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-            "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+        "@babel/helper-hoist-variables": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.12.10"
+                "@babel/types": "^7.22.5"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -3899,18 +3913,24 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-            "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.12.11"
+                "@babel/types": "^7.22.5"
             }
         },
+        "@babel/helper-string-parser": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "dev": true
+        },
         "@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true
         },
         "@babel/helpers": {
@@ -3925,102 +3945,59 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-            "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
             "dev": true
         },
         "@babel/template": {
-            "version": "7.12.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.12.7",
-                "@babel/types": "^7.12.7"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.10.4"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.4",
-                        "chalk": "^2.0.0",
-                        "js-tokens": "^4.0.0"
-                    }
-                }
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
             }
         },
         "@babel/traverse": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-            "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.12.11",
-                "@babel/generator": "^7.12.11",
-                "@babel/helper-function-name": "^7.12.11",
-                "@babel/helper-split-export-declaration": "^7.12.11",
-                "@babel/parser": "^7.12.11",
-                "@babel/types": "^7.12.12",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.19"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.10.4"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.4",
-                        "chalk": "^2.0.0",
-                        "js-tokens": "^4.0.0"
-                    }
-                }
+                "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-            "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.12.11",
-                "lodash": "^4.17.19",
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -4153,6 +4130,45 @@
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
             "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
             "dev": true
+        },
+        "@jridgewell/gen-mapping": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "dev": true
+        },
+        "@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
         },
         "@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -4454,9 +4470,9 @@
             }
         },
         "chalk": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-            "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
@@ -4679,12 +4695,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "fill-range": {
@@ -5001,9 +5011,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "dev": true
                 }
             }
@@ -5331,9 +5341,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "dev": true
                 }
             }
@@ -5959,9 +5969,9 @@
             "dev": true
         },
         "semver": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true
         },
         "serialize-javascript": {


### PR DESCRIPTION
We need this in order to merge dependabot updates as `npm audit` always returns an error.
Honestly, we need this in order to merge anything if we want to rely on a green CI state.

I needed to increase the memory limit as otherwise the tests would fail.
As it works for me locally I've opted to only set the increased limit in CI.

```
debian@box: /home/debian/projects/contrib/javascript git:(release-1.x)
➜   npm audit --audit-level=critical
# npm audit report

@babel/traverse  <7.23.2
Severity: critical
Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code - https://github.com/advisories/GHSA-67hx-6x53-jw92
fix available via `npm audit fix`
node_modules/@babel/traverse

semver  <5.7.2 || >=6.0.0 <6.3.1
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix`
node_modules/istanbul-lib-instrument/node_modules/semver
node_modules/make-dir/node_modules/semver
node_modules/semver

2 vulnerabilities (1 moderate, 1 critical)

To address all issues, run:
  npm audit fix
debian@box: /home/debian/projects/contrib/javascript git:(release-1.x)
➜   npm audit fix

changed 1 package, and audited 340 packages in 2s

42 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
debian@box: /home/debian/projects/contrib/javascript git:(release-1.x) ✗
➜   npm audit --audit-level=critical
found 0 vulnerabilities
```