### PR TITLE
ci: use node lts in deploy docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: '20'
       # Pre-check to validate that versions match between package.json
       # and package-lock.json. Needs to run before npm install
       - name: Validate package.json and package-lock.json versions


### PR DESCRIPTION
Some library uses an operator which is not available in node 14 and therefore deploy docs always fails. We host this documentation on gh-pages and link to it in our `README.md` so this should be up to date.