### PR TITLE
fix: add support for tls-server-name in KubeConfig

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -225,6 +225,10 @@ export class KubeConfig implements SecurityAuthentication {
             agentOptions.rejectUnauthorized = false;
         }
 
+        if (cluster && cluster.tlsServerName) {
+            agentOptions.servername = cluster.tlsServerName
+        }
+
         if (user && user.username) {
             const auth = Buffer.from(`${user.username}:${user.password}`).toString('base64');
             context.setHeaderParam('Authorization', `Basic ${auth}`);
@@ -514,6 +518,10 @@ export class KubeConfig implements SecurityAuthentication {
 
         if (cluster != null && cluster.skipTLSVerify) {
             opts.rejectUnauthorized = false;
+        }
+        if (cluster != null && cluster.tlsServerName) {
+            // WebSocket.ClientOptions types are missing the servername
+            (opts as any).servername = cluster.tlsServerName;
         }
         const ca = cluster != null ? bufferFromFileOrString(cluster.caFile, cluster.caData) : null;
         if (ca) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -226,7 +226,7 @@ export class KubeConfig implements SecurityAuthentication {
         }
 
         if (cluster && cluster.tlsServerName) {
-            agentOptions.servername = cluster.tlsServerName
+            agentOptions.servername = cluster.tlsServerName;
         }
 
         if (user && user.username) {

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -285,7 +285,7 @@ describe('KubeConfig', () => {
             const expectedAgent = new https.Agent({
                 ca: Buffer.from('CADATA2', 'utf-8'),
                 cert: Buffer.from('USER_CADATA', 'utf-8'),
-                key:  Buffer.from('USER_CKDATA', 'utf-8'),
+                key: Buffer.from('USER_CKDATA', 'utf-8'),
                 passphrase: undefined,
                 pfx: undefined,
                 rejectUnauthorized: false,
@@ -311,7 +311,7 @@ describe('KubeConfig', () => {
             const expectedAgent = new https.Agent({
                 ca: Buffer.from('CADATA2', 'utf-8'),
                 cert: Buffer.from('USER2_CADATA', 'utf-8'),
-                key:  Buffer.from('USER2_CKDATA', 'utf-8'),
+                key: Buffer.from('USER2_CKDATA', 'utf-8'),
                 passphrase: undefined,
                 pfx: undefined,
                 rejectUnauthorized: false,

--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -21,7 +21,7 @@ export interface Cluster {
     readonly caData?: string;
     caFile?: string;
     readonly server: string;
-    readonly tlsServerName?: string
+    readonly tlsServerName?: string;
     readonly skipTLSVerify: boolean;
 }
 

--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -21,6 +21,7 @@ export interface Cluster {
     readonly caData?: string;
     caFile?: string;
     readonly server: string;
+    readonly tlsServerName?: string
     readonly skipTLSVerify: boolean;
 }
 
@@ -38,6 +39,7 @@ export function exportCluster(cluster: Cluster): any {
             'certificate-authority-data': cluster.caData,
             'certificate-authority': cluster.caFile,
             'insecure-skip-tls-verify': cluster.skipTLSVerify,
+            'tls-server-name': cluster.tlsServerName,
         },
     };
 }
@@ -60,6 +62,7 @@ function clusterIterator(onInvalidEntry: ActionOnInvalid): _.ListIterator<any, C
                 name: elt.name,
                 server: elt.cluster.server.replace(/\/$/, ''),
                 skipTLSVerify: elt.cluster['insecure-skip-tls-verify'] === true,
+                tlsServerName: elt.cluster['tls-server-name'],
             };
         } catch (err) {
             switch (onInvalidEntry) {

--- a/testdata/tls-server-name-kubeconfig.yaml
+++ b/testdata/tls-server-name-kubeconfig.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Q0FEQVRBMg==
+    server: http://example2.com
+    insecure-skip-tls-verify: true
+    tls-server-name: kube.example2.com
+  name: cluster
+- cluster:
+    certificate-authority-data: Q0FEQVRBMg==
+    server: http://example2.com
+    insecure-skip-tls-verify: true
+  name: cluster2
+
+contexts:
+- context:
+    cluster: cluster
+    user: user
+  name: context
+
+current-context: context
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    client-certificate-data: VVNFUl9DQURBVEE=
+    client-key-data: VVNFUl9DS0RBVEE=


### PR DESCRIPTION
The feature that was added in 076531effb9d072d5544f7f36fb6a820ddd037a4 was missing in the 1.x release branch – we ported the existing feature from there.