### PR TITLE
fix: Fix TypeError of topNodes

### DIFF
--- a/src/top.ts
+++ b/src/top.ts
@@ -1,4 +1,4 @@
-import { CoreV1Api, V1Node, V1Pod, V1PodList, V1PodStatus } from './gen/api';
+import { CoreV1Api, V1Node, V1Pod, V1PodList } from './gen/api';
 import { Metrics, PodMetric } from './metrics';
 import {
     add,
@@ -63,11 +63,7 @@ export async function topNodes(api: CoreV1Api): Promise<NodeStatus[]> {
         let totalPodMem: number | bigint = 0;
         let totalPodMemLimit: number | bigint = 0;
         let pods = await podsForNode(api, node.metadata!.name!);
-        pods = pods.filter(
-            (pod: V1Pod) =>
-                // @ts-ignore
-                pod.status!.phase === 'Running' || pod.status!.phase === V1PodStatus.PhaseEnum.Running,
-        );
+        pods = pods.filter((pod: V1Pod) => pod.status?.phase === 'Running');
         pods.forEach((pod: V1Pod) => {
             const cpuTotal = totalCPU(pod);
             totalPodCPU = add(totalPodCPU, cpuTotal.request);


### PR DESCRIPTION
Hi there,
This is a fix of topNodes(). It seems to have stopped working due to TypeError since 0.19.x.

```
TypeError: Cannot read properties of undefined (reading 'Running')
    at path/to/node_modules/@kubernetes/client-node/dist/top.js:61:92
    at Array.filter (<anonymous>)\n
    at Object.topNodes (path/to/node_modules/@kubernetes/client-node/dist/top.js:59:21)
...
```