### PR TITLE
Revert "fix: top running pods"

### DIFF
--- a/src/top.ts
+++ b/src/top.ts
@@ -1,4 +1,4 @@
-import { CoreV1Api, V1Node, V1Pod, V1PodList, V1PodStatus } from './gen/api';
+import { CoreV1Api, V1Node, V1Pod, V1PodList } from './gen/api';
 import { Metrics, PodMetric } from './metrics';
 import {
     add,
@@ -63,11 +63,7 @@ export async function topNodes(api: CoreV1Api): Promise<NodeStatus[]> {
         let totalPodMem: number | bigint = 0;
         let totalPodMemLimit: number | bigint = 0;
         let pods = await podsForNode(api, node.metadata!.name!);
-        pods = pods.filter(
-            (pod: V1Pod) =>
-                // @ts-ignore
-                pod.status!.phase === 'Running' || pod.status!.phase === V1PodStatus.PhaseEnum.Running,
-        );
+        pods = pods.filter((pod: V1Pod) => pod.status!.phase === 'Running');
         pods.forEach((pod: V1Pod) => {
             const cpuTotal = totalCPU(pod);
             totalPodCPU = add(totalPodCPU, cpuTotal.request);


### PR DESCRIPTION
This solves issue #1447

This reverts commit 3520057e7ce2754254f2c34897be76a4cde58ea4.

V1PodStatus.PhaseEnum does not exist, causing topNodes to crash with the following error:

TypeError: Cannot read properties of undefined (reading 'Running')
    at /home/user/code/misc/k8s-js-bug/node_modules/@kubernetes/client-node/dist/top.js:61:92
    at Array.filter (<anonymous>)
    at Object.topNodes (/home/user/code/misc/k8s-js-bug/node_modules/@kubernetes/client-node/dist/top.js:59:21)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async main (/home/user/code/misc/k8s-js-bug/main.js:10:21)