### PR TITLE
[release-1.x] ci: add generate javascript action

### DIFF
--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -1,0 +1,53 @@
+name: Generate
+
+on:
+  workflow_dispatch:
+    inputs:
+      kubernetesBranch:
+        type: string
+        required: true
+        description: 'The remote kubernetes release branch to fetch openapi spec. .e.g. "release-1.23"'
+      genCommit:
+        type: string
+        required: true
+        default: '7ac2e3d8c036a64e265a38220c91cee3ec557583'
+        description: 'The commit to use for the kubernetes-client/gen repo'
+
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Javascript
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Generate Openapi
+        run: |
+          echo "export KUBERNETES_BRANCH=${{ github.event.inputs.kubernetesBranch }} >> ./settings"
+          echo "export GEN_COMMIT="${{ github.event.inputs.genCommit }}" >> ./settings"
+          ./generate-client.sh
+      - name: Generate Branch Name
+        run: |
+          SUFFIX=$(openssl rand -hex 4)
+          echo "BRANCH=automated-generate-$SUFFIX" >> $GITHUB_ENV
+      - name: Commit and push
+        run: |
+          # Commit and push
+          git config user.email "k8s.ci.robot@gmail.com"
+          git config user.name "Kubernetes Prow Robot"
+          git checkout -b "$BRANCH"
+          git add .
+          # we modify the settings file in "Generate Openapi" but do not want to commit this
+          git reset settings
+          git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
+          git push origin "$BRANCH"
+      - name: Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ${{ env.BRANCH }}
+          destination_branch: ${{ github.ref_name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}"


### PR DESCRIPTION
I ported over the generate-javascript action and made some modifications, mainly removing temporary fixues for upstream issues.

Here is an example run I've did with the latest kubernetes RC, it seems like nothing has changed regarding the API as there are no changes in the generated code: https://github.com/kubernetes-client/javascript/actions/runs/7070150421