### PR TITLE
fix: do not overwrite current context

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -259,7 +259,7 @@ export class KubeConfig {
     }
 
     public mergeConfig(config: KubeConfig, preserveContext: boolean = false): void {
-        if (!preserveContext) {
+        if (!preserveContext && config.currentContext) {
             this.currentContext = config.currentContext;
         }
         config.clusters.forEach((cluster: Cluster) => {


### PR DESCRIPTION
with a null/undefined one

When having multiple configs in `KUBECONFIG` only one of them may have the current context set
but it will be overwritten by an empty value if preserveContext is not explicitly set
which is not the case when using kubectl binary