### PR TITLE
fix: use load from cluster when default service mount is disabled

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -369,7 +369,10 @@ export class KubeConfig {
             }
         }
 
-        if (fileExists(Config.SERVICEACCOUNT_TOKEN_PATH)) {
+        if (
+            fileExists(Config.SERVICEACCOUNT_TOKEN_PATH) ||
+            (process.env.TOKEN_FILE_PATH !== undefined && process.env.TOKEN_FILE_PATH !== '')
+        ) {
             this.loadFromCluster();
             return;
         }


### PR DESCRIPTION
fixing a bug in #1549