### PR TITLE
feat: add reexports for AbortError and FetchError from node-fetch to aid instanceof checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@types/js-yaml": "^4.0.1",
                 "@types/node": "^20.3.1",
-                "@types/node-fetch": "^2.6.3",
+                "@types/node-fetch": "^2.6.9",
                 "@types/stream-buffers": "^3.0.3",
                 "@types/tar": "^6.1.1",
                 "@types/underscore": "^1.8.9",
@@ -296,25 +296,12 @@
             }
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
-            "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+            "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
             "dependencies": {
                 "@types/node": "*",
-                "form-data": "^3.0.0"
-            }
-        },
-        "node_modules/@types/node-fetch/node_modules/form-data": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
+                "form-data": "^4.0.0"
             }
         },
         "node_modules/@types/stream-buffers": {
@@ -2917,24 +2904,12 @@
             }
         },
         "@types/node-fetch": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
-            "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+            "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
             "requires": {
                 "@types/node": "*",
-                "form-data": "^3.0.0"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-                    "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                }
+                "form-data": "^4.0.0"
             }
         },
         "@types/stream-buffers": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dependencies": {
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^20.3.1",
-        "@types/node-fetch": "^2.6.3",
+        "@types/node-fetch": "^2.6.9",
         "@types/stream-buffers": "^3.0.3",
         "@types/tar": "^6.1.1",
         "@types/underscore": "^1.8.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,6 @@ export * from './patch';
 export * from './metrics';
 export * from './object';
 export { ConfigOptions, User, Cluster, Context } from './config_types';
+
+// Export AbortError and FetchError so that instanceof checks in user code will definitely use the same instances
+export { AbortError, FetchError } from 'node-fetch';


### PR DESCRIPTION
`instanceof` checks must use the same instance, so if a user installed a different version of `node-fetch` in their project the `instanceof` checks would fail. By reexporting we ensure that a user can get the exact same instance that this client would return.