### PR TITLE
Update generate-javascript.yml

### DIFF
--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -10,7 +10,7 @@ on:
       genCommit:
         type: string
         required: true
-        default: 'b32dcd6'
+        default: 'f0bb447'
         description: 'The commit to use for the kubernetes-client/gen repo'
 
 
@@ -32,7 +32,7 @@ jobs:
           # apply https://github.com/kubernetes-client/gen/pull/224
           git config --global user.name "Github Actions"
           git config --global user.email "<>"
-          git cherry-pick --strategy=recursive -X theirs c557f7f 0ef2cec 9701a7c
+          git cherry-pick --strategy=recursive -X theirs c557f7f b32dcd6 0ef2cec 9701a7c
           rm -rf gen/.git
       # apply https://github.com/kubernetes-client/gen/pull/237
       - name: Patch Dockerfile


### PR DESCRIPTION
Another attempt to fix the generate workflow, reverts #1627 and changes the default commit.

Note that when we generate for the release branch, we should move forward.

The truth is that we switch permanently to the fetch based client.