### PR TITLE
[MASTER] fix: use correct types for websocket

### DIFF
--- a/src/attach.ts
+++ b/src/attach.ts
@@ -23,7 +23,7 @@ export class Attach {
         stderr: stream.Writable | any,
         stdin: stream.Readable | any,
         tty: boolean,
-    ): Promise<WebSocket> {
+    ): Promise<WebSocket.WebSocket> {
         const query = {
             container: containerName,
             stderr: stderr != null,

--- a/src/attach_test.ts
+++ b/src/attach_test.ts
@@ -49,7 +49,7 @@ describe('Attach', () => {
         it('should correctly attach to streams', async () => {
             const kc = new KubeConfig();
             const fakeWebSocketInterface: WebSocketInterface = mock(WebSocketHandler);
-            const fakeWebSocket: WebSocket = mock(WebSocket);
+            const fakeWebSocket: WebSocket.WebSocket = mock(WebSocket);
             const callAwaiter: CallAwaiter = new CallAwaiter();
             const attach = new Attach(kc, instance(fakeWebSocketInterface));
             const osStream = new ResizableWriteableStreamBuffer();
@@ -63,7 +63,7 @@ describe('Attach', () => {
             const path = `/api/v1/namespaces/${namespace}/pods/${pod}/attach`;
             const args = `container=${container}&stderr=true&stdin=true&stdout=true&tty=false`;
 
-            const fakeConn: WebSocket = instance(fakeWebSocket);
+            const fakeConn: WebSocket.WebSocket = instance(fakeWebSocket);
             when(fakeWebSocketInterface.connect(`${path}?${args}`, null, anyFunction())).thenResolve(
                 fakeConn,
             );

--- a/src/cp_test.ts
+++ b/src/cp_test.ts
@@ -44,7 +44,7 @@ describe('Cp', () => {
         it('should run extract tar command to a url', async () => {
             const kc = new KubeConfig();
             const fakeWebSocketInterface: WebSocketInterface = mock(WebSocketHandler);
-            const fakeWebSocket: WebSocket = mock(WebSocket) as WebSocket;
+            const fakeWebSocket: WebSocket.WebSocket = mock(WebSocket) as WebSocket.WebSocket;
             const callAwaiter: CallAwaiter = new CallAwaiter();
             const exec = new Exec(kc, instance(fakeWebSocketInterface));
             const cp = new Cp(kc, exec);
@@ -67,7 +67,7 @@ describe('Cp', () => {
             };
             const queryStr = querystring.stringify(query);
 
-            const fakeConn: WebSocket = instance(fakeWebSocket);
+            const fakeConn: WebSocket.WebSocket = instance(fakeWebSocket);
             when(fakeWebSocketInterface.connect(`${path}?${queryStr}`, null, anyFunction())).thenResolve(
                 fakeConn,
             );

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -39,7 +39,7 @@ export class Exec {
         stdin: stream.Readable | null,
         tty: boolean,
         statusCallback?: (status: V1Status) => void,
-    ): Promise<WebSocket> {
+    ): Promise<WebSocket.WebSocket> {
         const query = {
             stdout: stdout != null,
             stderr: stderr != null,

--- a/src/exec_test.ts
+++ b/src/exec_test.ts
@@ -56,7 +56,7 @@ describe('Exec', () => {
         it('should correctly attach to streams', async () => {
             const kc = new KubeConfig();
             const fakeWebSocketInterface: WebSocketInterface = mock(WebSocketHandler);
-            const fakeWebSocket: WebSocket = mock(WebSocket);
+            const fakeWebSocket: WebSocket.WebSocket = mock(WebSocket);
             const callAwaiter: CallAwaiter = new CallAwaiter();
             const exec = new Exec(kc, instance(fakeWebSocketInterface));
             const osStream = new ResizableWriteableStreamBuffer();
@@ -73,7 +73,7 @@ describe('Exec', () => {
 
             let statusOut = {} as V1Status;
 
-            const fakeConn: WebSocket = instance(fakeWebSocket);
+            const fakeConn: WebSocket.WebSocket = instance(fakeWebSocket);
             when(fakeWebSocketInterface.connect(`${path}?${args}`, null, anyFunction())).thenResolve(
                 fakeConn,
             );

--- a/src/portforward.ts
+++ b/src/portforward.ts
@@ -24,7 +24,7 @@ export class PortForward {
         err: stream.Writable | null,
         input: stream.Readable,
         retryCount: number = 0,
-    ): Promise<WebSocket | (() => WebSocket | null)> {
+    ): Promise<WebSocket.WebSocket | (() => WebSocket.WebSocket | null)> {
         if (targetPorts.length === 0) {
             throw new Error('You must provide at least one port to forward to.');
         }
@@ -41,7 +41,7 @@ export class PortForward {
             needsToReadPortNumber[index * 2 + 1] = true;
         });
         const path = `/api/v1/namespaces/${namespace}/pods/${podName}/portforward?${queryStr}`;
-        const createWebSocket = (): Promise<WebSocket> => {
+        const createWebSocket = (): Promise<WebSocket.WebSocket> => {
             return this.handler.connect(path, null, (streamNum: number, buff: Buffer | string): boolean => {
                 if (streamNum >= targetPorts.length * 2) {
                     return !this.disconnectOnErr;

--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -11,7 +11,7 @@ export interface WebSocketInterface {
         path: string,
         textHandler: ((text: string) => boolean) | null,
         binaryHandler: ((stream: number, buff: Buffer) => boolean) | null,
-    ): Promise<WebSocket>;
+    ): Promise<WebSocket.WebSocket>;
 }
 
 export class WebSocketHandler implements WebSocketInterface {
@@ -50,7 +50,7 @@ export class WebSocketHandler implements WebSocketInterface {
     }
 
     public static handleStandardInput(
-        ws: WebSocket,
+        ws: WebSocket.WebSocket,
         stdin: stream.Readable | any,
         streamNum: number = 0,
     ): boolean {
@@ -74,11 +74,11 @@ export class WebSocketHandler implements WebSocketInterface {
 
     public static async processData(
         data: string | Buffer,
-        ws: WebSocket | null,
-        createWS: () => Promise<WebSocket>,
+        ws: WebSocket.WebSocket | null,
+        createWS: () => Promise<WebSocket.WebSocket>,
         streamNum: number = 0,
         retryCount: number = 3,
-    ): Promise<WebSocket | null> {
+    ): Promise<WebSocket.WebSocket | null> {
         const buff = Buffer.alloc(data.length + 1);
 
         buff.writeInt8(streamNum, 0);
@@ -108,17 +108,17 @@ export class WebSocketHandler implements WebSocketInterface {
     }
 
     public static restartableHandleStandardInput(
-        createWS: () => Promise<WebSocket>,
+        createWS: () => Promise<WebSocket.WebSocket>,
         stdin: stream.Readable | any,
         streamNum: number = 0,
         retryCount: number = 3,
-    ): () => WebSocket | null {
+    ): () => WebSocket.WebSocket | null {
         if (retryCount < 0) {
             throw new Error("retryCount can't be lower than 0.");
         }
 
         let queue: Promise<void> = Promise.resolve();
-        let ws: WebSocket | null = null;
+        let ws: WebSocket.WebSocket | null = null;
 
         stdin.on('data', (data) => {
             queue = queue.then(async () => {
@@ -138,7 +138,7 @@ export class WebSocketHandler implements WebSocketInterface {
     // factory is really just for test injection
     public constructor(
         readonly config: KubeConfig,
-        readonly socketFactory?: (uri: string, opts: WebSocket.ClientOptions) => WebSocket,
+        readonly socketFactory?: (uri: string, opts: WebSocket.ClientOptions) => WebSocket.WebSocket,
     ) {}
 
     /**
@@ -153,7 +153,7 @@ export class WebSocketHandler implements WebSocketInterface {
         path: string,
         textHandler: ((text: string) => boolean) | null,
         binaryHandler: ((stream: number, buff: Buffer) => boolean) | null,
-    ): Promise<WebSocket> {
+    ): Promise<WebSocket.WebSocket> {
         const cluster = this.config.getCurrentCluster();
         if (!cluster) {
             throw new Error('No cluster is defined.');
@@ -168,7 +168,7 @@ export class WebSocketHandler implements WebSocketInterface {
 
         await this.config.applyToHTTPSOptions(opts);
 
-        return await new Promise<WebSocket>((resolve, reject) => {
+        return await new Promise<WebSocket.WebSocket>((resolve, reject) => {
             const client = this.socketFactory
                 ? this.socketFactory(uri, opts)
                 : new WebSocket(uri, protocols, opts);

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -114,13 +114,16 @@ describe('WebSocket', () => {
             } as User,
         ];
 
-        const mockWs = {} as WebSocket;
+        const mockWs = {} as WebSocket.WebSocket;
         let uriOut = '';
 
-        const handler = new WebSocketHandler(kc, (uri: string, opts: WebSocket.ClientOptions): WebSocket => {
-            uriOut = uri;
-            return mockWs as WebSocket;
-        });
+        const handler = new WebSocketHandler(
+            kc,
+            (uri: string, opts: WebSocket.ClientOptions): WebSocket.WebSocket => {
+                uriOut = uri;
+                return mockWs as WebSocket.WebSocket;
+            },
+        );
         const path = '/some/path';
 
         const promise = handler.connect(path, null, null);
@@ -162,13 +165,16 @@ describe('WebSocket', () => {
             } as User,
         ];
 
-        const mockWs = {} as WebSocket;
+        const mockWs = {} as WebSocket.WebSocket;
         let uriOut = '';
 
-        const handler = new WebSocketHandler(kc, (uri: string, opts: WebSocket.ClientOptions): WebSocket => {
-            uriOut = uri;
-            return mockWs as WebSocket;
-        });
+        const handler = new WebSocketHandler(
+            kc,
+            (uri: string, opts: WebSocket.ClientOptions): WebSocket.WebSocket => {
+                uriOut = uri;
+                return mockWs as WebSocket.WebSocket;
+            },
+        );
         const path = '/some/path';
 
         const promise = handler.connect(path, null, null);
@@ -228,13 +234,16 @@ describe('WebSocket', () => {
             close: () => {
                 closeCount++;
             },
-        } as WebSocket;
+        } as WebSocket.WebSocket;
         let uriOut = '';
 
-        const handler = new WebSocketHandler(kc, (uri: string, opts: WebSocket.ClientOptions): WebSocket => {
-            uriOut = uri;
-            return mockWs as WebSocket;
-        });
+        const handler = new WebSocketHandler(
+            kc,
+            (uri: string, opts: WebSocket.ClientOptions): WebSocket.WebSocket => {
+                uriOut = uri;
+                return mockWs as WebSocket.WebSocket;
+            },
+        );
         const path = '/some/path';
 
         let textReceived = '';
@@ -296,7 +305,7 @@ describe('WebSocket', () => {
 
 describe('Restartable Handle Standard Input', () => {
     it('should throw on negative retry', () => {
-        const p = new Promise<WebSocket>(() => {});
+        const p = new Promise<WebSocket.WebSocket>(() => {});
         expect(() => WebSocketHandler.restartableHandleStandardInput(() => p, null, 0, -1)).to.throw(
             "retryCount can't be lower than 0.",
         );
@@ -311,10 +320,10 @@ describe('Restartable Handle Standard Input', () => {
         WebSocketHandler.processData(
             'some test data',
             null,
-            (): Promise<WebSocket> => {
-                return new Promise<WebSocket>((resolve) => {
+            (): Promise<WebSocket.WebSocket> => {
+                return new Promise<WebSocket.WebSocket>((resolve) => {
                     count++;
-                    resolve(ws as WebSocket);
+                    resolve(ws as WebSocket.WebSocket);
                 });
             },
             0,


### PR DESCRIPTION
Same as #1664 but for `master` as well as I'm not entirely sure when we will promote `release-1.x`.

* Closes #1662