### PR TITLE
make namespace in Object header optional

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -28,7 +28,7 @@ type KubernetesObjectHeader<T extends KubernetesObject | KubernetesObject> = Pic
 > & {
     metadata: {
         name: string;
-        namespace: string;
+        namespace?: string;
     };
 };
 


### PR DESCRIPTION
the `KubernetesObjectHeader` type is currently wrong as a namespace is never required.
Clusterwide resources do not need a namespace at all and namespace resources will be defaulted to the `default` namespace (although something we might want to think about removing in a SDK.)