### PR TITLE
server side apply support

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 npm test && npm run lint

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -2,6 +2,9 @@
  * Valid Content-Type header values for patch operations.  See
  * https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
  * for details.
+ * 
+ * Additionally for Server-Side Apply https://kubernetes.io/docs/reference/using-api/server-side-apply/
+ * and https://kubernetes.io/docs/reference/using-api/server-side-apply/#api-implementation
  */
 export enum PatchStrategy {
     /** Diff-like JSON format. */
@@ -10,4 +13,6 @@ export enum PatchStrategy {
     MergePatch = 'application/merge-patch+json',
     /** Merge with different strategies depending on field metadata. */
     StrategicMergePatch = 'application/strategic-merge-patch+json',
+    /** Server-Side Apply */
+    ServerSideApply = 'application/apply-patch+yaml'
 }

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -2,7 +2,7 @@
  * Valid Content-Type header values for patch operations.  See
  * https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
  * for details.
- * 
+ *
  * Additionally for Server-Side Apply https://kubernetes.io/docs/reference/using-api/server-side-apply/
  * and https://kubernetes.io/docs/reference/using-api/server-side-apply/#api-implementation
  */
@@ -14,5 +14,5 @@ export enum PatchStrategy {
     /** Merge with different strategies depending on field metadata. */
     StrategicMergePatch = 'application/strategic-merge-patch+json',
     /** Server-Side Apply */
-    ServerSideApply = 'application/apply-patch+yaml'
+    ServerSideApply = 'application/apply-patch+yaml',
 }


### PR DESCRIPTION
add `application/apply-patch+yaml` Patch Strategy to allow [server-side apply ](https://kubernetes.io/docs/reference/using-api/server-side-apply/#api-implementation)

from @eplightning 's feedback on release

also husky cleaned up  deprecated part of one of it's scripts](https://github.com/typicode/husky/issues/1468)