### PR TITLE
chore: update ws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "stream-buffers": "^3.0.2",
         "tar": "^7.0.0",
         "tslib": "^2.4.1",
-        "ws": "^8.11.0"
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@types/byline": "^4.2.31",
@@ -4368,6 +4368,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "stream-buffers": "^3.0.2",
     "tar": "^7.0.0",
     "tslib": "^2.4.1",
-    "ws": "^8.11.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/byline": "^4.2.31",


### PR DESCRIPTION
Update `ws` to version 8.18 because of a security vulnerability and npm dependencies to latest versions according to our version constraints.
