### PR TITLE
chore: update ws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "tslib": "^2.5.0",
                 "underscore": "^1.9.1",
                 "url-parse": "^1.4.3",
-                "ws": "^8.13.0"
+                "ws": "^8.18.0"
             },
             "devDependencies": {
                 "@types/byline": "^4.2.31",
@@ -2794,6 +2794,7 @@
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "tslib": "^2.5.0",
         "underscore": "^1.9.1",
         "url-parse": "^1.4.3",
-        "ws": "^8.13.0"
+        "ws": "^8.18.0"
     },
     "devDependencies": {
         "@types/byline": "^4.2.31",


### PR DESCRIPTION
Update `ws` to version 8.18 because of a security vulnerability and npm dependencies to latest versions according to our version constraints.
