### PR TITLE
ci: test against node 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # Remove specific version from 20 when https://github.com/tschaub/mock-fs/issues/380 is fixed
-        node: [ '22', '20.7.0', '18', '16' ]
+        node: [ '22', '20.7.0', '18' ]
     name: Node ${{ matrix.node }} validation
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # Remove specific version from 20 when https://github.com/tschaub/mock-fs/issues/380 is fixed
-        node: [ '20.7.0', '18', '16' ]
+        node: [ '22', '20.7.0', '18', '16' ]
     name: Node ${{ matrix.node }} validation
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Node 22 will become LTS in October 2024

Refs: https://github.com/nodejs/release

On a related note, Node 16 has been EOL for over a year. I'd be happy to remove it if the project wishes to do so.