### PR TITLE
src: remove use of util.isUndefined()

### DIFF
--- a/src/portforward.ts
+++ b/src/portforward.ts
@@ -1,7 +1,6 @@
 import WebSocket = require('isomorphic-ws');
 import querystring = require('querystring');
 import stream = require('stream');
-import { isUndefined } from 'util';
 
 import { KubeConfig } from './config';
 import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
@@ -13,7 +12,7 @@ export class PortForward {
     // handler is a parameter really only for injecting for testing.
     constructor(config: KubeConfig, disconnectOnErr?: boolean, handler?: WebSocketInterface) {
         this.handler = handler || new WebSocketHandler(config);
-        this.disconnectOnErr = isUndefined(disconnectOnErr) ? true : disconnectOnErr;
+        this.disconnectOnErr = disconnectOnErr === undefined ? true : disconnectOnErr;
     }
 
     // TODO: support multiple ports for real...


### PR DESCRIPTION
This method has been deprecated in Node.js.

It looks like a similar change was made to the master branch as part of #1320, but it was not cherry-picked to release-1.x. I'm not sure how the project handles this, but I figured I would silence the deprecation warning. If #1320 is going to be cherry-picked, feel free to close this.