### PR TITLE
deps: replace `byline` with `node:readline`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "@types/tar": "^6.1.1",
         "@types/underscore": "^1.8.9",
         "@types/ws": "^8.5.4",
-        "byline": "^5.0.0",
         "form-data": "^4.0.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
@@ -78,7 +77,6 @@
         "ws": "^8.13.0"
     },
     "devDependencies": {
-        "@types/byline": "^4.2.31",
         "@types/chai": "^4.3.0",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.1",


### PR DESCRIPTION
`byline` was being used to read a stream line by line. The core `node:readline` module appears to provide the functionality needed by this package, so remove an external dependency.