### PR TITLE
logs: add support for sinceTime option

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -37,6 +37,12 @@ export interface LogOptions {
     sinceSeconds?: number;
 
     /**
+     * Only return logs after a specific date (RFC3339). Defaults to all logs.
+     * Only one of sinceSeconds or sinceTime may be specified.
+     */
+    sinceTime?: string;
+
+    /**
      * If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation
      * of the container or sinceSeconds or sinceTime
      */
@@ -63,6 +69,12 @@ export function AddOptionsToSearchParams(
     searchParams.set('previous', options?.previous?.toString() || 'false');
     if (options?.sinceSeconds) {
         searchParams.set('sinceSeconds', options?.sinceSeconds?.toString() || 'false');
+    }
+    if (options?.sinceTime) {
+        if (options?.sinceSeconds) {
+            throw new Error('at most one of sinceTime or sinceSeconds may be specified');
+        }
+        searchParams.set('sinceTime', options?.sinceTime);
     }
     if (options?.tailLines) {
         searchParams.set('tailLines', options?.tailLines?.toString() || 'false');

--- a/src/log_test.ts
+++ b/src/log_test.ts
@@ -5,8 +5,8 @@ import { URLSearchParams } from 'url';
 describe('Log', () => {
     describe('AddOptionsToSearchParams', () => {
         it('should add options to search params', () => {
-            const searchParams = new URLSearchParams();
-            const options: LogOptions = {
+            let searchParams = new URLSearchParams();
+            let options: LogOptions = {
                 follow: true,
                 limitBytes: 100,
                 pretty: true,
@@ -23,6 +23,12 @@ describe('Log', () => {
             expect(searchParams.get('sinceSeconds')).to.equal('1');
             expect(searchParams.get('tailLines')).to.equal('1');
             expect(searchParams.get('timestamps')).to.equal('true');
+
+            const sinceTime = new Date().toISOString();
+            searchParams = new URLSearchParams();
+            options = { sinceTime };
+            AddOptionsToSearchParams(options, searchParams);
+            expect(searchParams.get('sinceTime')).to.equal(sinceTime);
         });
         it('should use defaults for', () => {
             const searchParams = new URLSearchParams();
@@ -32,6 +38,17 @@ describe('Log', () => {
             expect(searchParams.get('pretty')).to.equal('false');
             expect(searchParams.get('previous')).to.equal('false');
             expect(searchParams.get('timestamps')).to.equal('false');
+        });
+        it('sinceTime and sinceSeconds cannot be used together', () => {
+            const searchParams = new URLSearchParams();
+            const sinceTime = new Date().toISOString();
+            const options: LogOptions = {
+                sinceSeconds: 1,
+                sinceTime,
+            };
+            expect(() => {
+                AddOptionsToSearchParams(options, searchParams);
+            }).to.throw('at most one of sinceTime or sinceSeconds may be specified');
         });
     });
 });


### PR DESCRIPTION
This commit adds `sinceTime` support to `LogOptions`.

Fixes: https://github.com/kubernetes-client/javascript/issues/1673