### PR TITLE
refactor Node core module imports

### DIFF
--- a/examples/typescript/apply/apply-from-file-example.ts
+++ b/examples/typescript/apply/apply-from-file-example.ts
@@ -1,7 +1,7 @@
 // in a real program use require('@kubernetes/client-node')
 import * as k8s from '../../../dist';
 import * as yaml from 'js-yaml';
-import { promises as fs } from 'fs';
+import * as fs from 'node:fs/promises';
 
 /**
  * Replicate the functionality of `kubectl apply`.  That is, create the resources defined in the `specFile` if they do

--- a/examples/typescript/exec/exec-example.ts
+++ b/examples/typescript/exec/exec-example.ts
@@ -1,6 +1,6 @@
 // in a real program use require('@kubernetes/client-node')
 import * as k8s from '../../../dist';
-import * as stream from 'stream';
+import * as stream from 'node:stream';
 
 const command = process.argv[2];
 

--- a/examples/typescript/port-forward/port-forward.ts
+++ b/examples/typescript/port-forward/port-forward.ts
@@ -1,6 +1,6 @@
 // in a real program use require('@kubernetes/client-node')
 import * as k8s from '../../../dist';
-import * as net from 'net';
+import * as net from 'node:net';
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -1,6 +1,6 @@
 import WebSocket = require('isomorphic-ws');
-import querystring = require('querystring');
-import stream = require('stream');
+import querystring = require('node:querystring');
+import stream = require('node:stream');
 
 import { KubeConfig } from './config';
 import { isResizable, ResizableStream, TerminalSizeQueue } from './terminal-size-queue';

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import https = require('https');
+import https = require('node:https');
 
 import { User } from './config_types';
 import WebSocket = require('isomorphic-ws');

--- a/src/azure_auth.ts
+++ b/src/azure_auth.ts
@@ -1,5 +1,5 @@
-import * as proc from 'child_process';
-import https = require('https');
+import * as proc from 'node:child_process';
+import https = require('node:https');
 import * as jsonpath from 'jsonpath-plus';
 
 import { Authenticator } from './auth';

--- a/src/azure_auth_test.ts
+++ b/src/azure_auth_test.ts
@@ -1,6 +1,6 @@
 import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { join } from 'path';
+import { join } from 'node:path';
 
 import { User, Cluster } from './config_types';
 import { AzureAuth } from './azure_auth';

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -3,8 +3,6 @@ import chaiAsPromised = require('chai-as-promised');
 
 import * as mock from 'ts-mockito';
 
-import http = require('http');
-
 import { V1ListMeta, V1Namespace, V1NamespaceList, V1ObjectMeta, V1Pod } from './api';
 import { deleteItems, deleteObject, ListWatch } from './cache';
 import { KubeConfig } from './config';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
-import fs = require('fs');
-import https = require('https');
+import fs = require('node:fs');
+import https = require('node:https');
 import yaml = require('js-yaml');
-import net = require('net');
-import path = require('path');
+import net = require('node:net');
+import path = require('node:path');
 
 import { Headers, RequestInit } from 'node-fetch';
 import * as api from './api';
@@ -32,7 +32,7 @@ import {
 } from './gen';
 import { OpenIDConnectAuth } from './oidc_auth';
 import WebSocket = require('isomorphic-ws');
-import child_process = require('child_process');
+import child_process = require('node:child_process');
 
 const SERVICEACCOUNT_ROOT: string = '/var/run/secrets/kubernetes.io/serviceaccount';
 const SERVICEACCOUNT_CA_PATH: string = SERVICEACCOUNT_ROOT + '/ca.crt';

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,12 +1,12 @@
-import { readFileSync } from 'fs';
-import * as https from 'https';
-import { Agent, RequestOptions } from 'https';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import * as https from 'node:https';
+import { Agent, RequestOptions } from 'node:https';
+import { join } from 'node:path';
 
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import mockfs = require('mock-fs');
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { Headers } from 'node-fetch';
 import { HttpMethod } from '.';

--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 export enum ActionOnInvalid {
     THROW = 'throw',

--- a/src/cp.ts
+++ b/src/cp.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { WritableStreamBuffer } from 'stream-buffers';
 import * as tar from 'tar';
 import * as tmp from 'tmp-promise';

--- a/src/cp_test.ts
+++ b/src/cp_test.ts
@@ -1,5 +1,5 @@
 import { anything, anyFunction, instance, mock, verify, when } from 'ts-mockito';
-import * as querystring from 'querystring';
+import * as querystring from 'node:querystring';
 import WebSocket = require('isomorphic-ws');
 
 import { CallAwaiter } from '../test';

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,5 +1,5 @@
 import WebSocket = require('isomorphic-ws');
-import querystring = require('querystring');
+import querystring = require('node:querystring');
 import stream = require('stream');
 
 import { V1Status } from './api';

--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -1,10 +1,10 @@
-import { OutgoingHttpHeaders } from 'http';
-import https = require('https');
+import { OutgoingHttpHeaders } from 'node:http';
+import https = require('node:https');
 
 import { Authenticator } from './auth';
 import { User } from './config_types';
 
-import child_process = require('child_process');
+import child_process = require('node:child_process');
 
 export interface CredentialStatus {
     readonly token: string;

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -2,14 +2,14 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 use(chaiAsPromised);
 
-import https from 'https';
-import { OutgoingHttpHeaders } from 'http';
+import https from 'node:https';
+import { OutgoingHttpHeaders } from 'node:http';
 
 import { ExecAuth } from './exec_auth';
 import { User } from './config_types';
-import { fail } from 'assert';
+import { fail } from 'node:assert';
 
-import child_process = require('child_process');
+import child_process = require('node:child_process');
 
 describe('ExecAuth', () => {
     it('should claim correctly', () => {

--- a/src/file_auth.ts
+++ b/src/file_auth.ts
@@ -1,5 +1,5 @@
-import fs = require('fs');
-import https = require('https');
+import fs = require('node:fs');
+import https = require('node:https');
 
 import { Authenticator } from './auth';
 import { User } from './config_types';

--- a/src/file_auth_test.ts
+++ b/src/file_auth_test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { OutgoingHttpHeaders } from 'http';
-import https from 'https';
+import { OutgoingHttpHeaders } from 'node:http';
+import https from 'node:https';
 import mockfs from 'mock-fs';
 
 import { User } from './config_types';

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -1,5 +1,5 @@
-import * as proc from 'child_process';
-import https = require('https');
+import * as proc from 'node:child_process';
+import https = require('node:https');
 import * as jsonpath from 'jsonpath-plus';
 
 import { Authenticator } from './auth';

--- a/src/gcp_auth_test.ts
+++ b/src/gcp_auth_test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
-import { join } from 'path';
+import { join } from 'node:path';
 
 import { User, Cluster } from './config_types';
 import { GoogleCloudPlatformAuth } from './gcp_auth';
 import { KubeConfig } from './config';
 import { HttpMethod, RequestContext } from './gen';
-import { Agent } from 'https';
+import { Agent } from 'node:https';
 
 describe('GoogleCloudPlatformAuth', () => {
     const testUrl1 = 'https://test-gcp.com';

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 import { AbortSignal } from 'node-fetch/externals';
-import { Writable } from 'stream';
-import { URL, URLSearchParams } from 'url';
+import { Writable } from 'node:stream';
 import { ApiException } from './api';
 import { KubeConfig } from './config';
 import { V1Status } from './gen';

--- a/src/log_test.ts
+++ b/src/log_test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { AddOptionsToSearchParams, LogOptions } from './log';
-import { URLSearchParams } from 'url';
 
 describe('Log', () => {
     describe('AddOptionsToSearchParams', () => {

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -1,8 +1,8 @@
-import { fail } from 'assert';
+import { fail } from 'node:assert';
 import { expect } from 'chai';
 import nock = require('nock');
 import { KubeConfig } from './config';
-import { V1Status, HttpException, ApiException } from './gen';
+import { V1Status, ApiException } from './gen';
 import { Metrics, NodeMetricsList, PodMetricsList } from './metrics';
 
 const emptyPodMetrics: PodMetricsList = {

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1,4 +1,4 @@
-import { fail } from 'assert';
+import { fail } from 'node:assert';
 import { expect } from 'chai';
 import nock = require('nock');
 import { Configuration, V1APIResource, V1APIResourceList, V1Secret } from './api';

--- a/src/oidc_auth.ts
+++ b/src/oidc_auth.ts
@@ -1,7 +1,6 @@
-import https from 'https';
+import https from 'node:https';
 import { Client, Issuer } from 'openid-client';
 import { base64url } from 'rfc4648';
-import { TextDecoder } from 'util';
 
 import { Authenticator } from './auth';
 import { User } from './config_types';

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
-import { OutgoingHttpHeaders } from 'http';
-import https from 'https';
+import { OutgoingHttpHeaders } from 'node:http';
+import https from 'node:https';
 import { base64url } from 'rfc4648';
-import { TextEncoder } from 'util';
 
 import { User } from './config_types';
 import { OpenIDConnectAuth } from './oidc_auth';

--- a/src/package_test.ts
+++ b/src/package_test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { URL } from 'url';
 
 // Generic set of tests to verify the package is built and configured correctly
 describe('package', () => {

--- a/src/portforward.ts
+++ b/src/portforward.ts
@@ -1,6 +1,6 @@
 import WebSocket = require('isomorphic-ws');
-import querystring = require('querystring');
-import stream = require('stream');
+import querystring = require('node:querystring');
+import stream = require('node:stream');
 
 import { KubeConfig } from './config';
 import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';

--- a/src/portforward_test.ts
+++ b/src/portforward_test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
-import { anyFunction, capture, instance, mock, reset, verify } from 'ts-mockito';
+import { anyFunction, capture, instance, mock, verify } from 'ts-mockito';
 
 import { KubeConfig } from './config';
 import { PortForward } from './portforward';

--- a/src/proto-client.ts
+++ b/src/proto-client.ts
@@ -1,5 +1,4 @@
-import http = require('http');
-import url = require('url');
+import http = require('node:http');
 
 import { KubeConfig } from './config';
 
@@ -8,7 +7,7 @@ export class ProtoClient {
 
     public async get(msgType: any, requestPath: string): Promise<any> {
         const server = this.config.getCurrentCluster()!.server;
-        const u = new url.URL(server);
+        const u = new URL(server);
         const options = {
             path: requestPath,
             hostname: u.hostname,

--- a/src/terminal-size-queue.ts
+++ b/src/terminal-size-queue.ts
@@ -1,4 +1,4 @@
-import { Readable, ReadableOptions } from 'stream';
+import { Readable, ReadableOptions } from 'node:stream';
 
 export interface ResizableStream {
     columns: number;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,7 +1,6 @@
 import { createInterface } from 'node:readline';
 import fetch from 'node-fetch';
 import { AbortSignal } from 'node-fetch/externals';
-import { URL } from 'url';
 import { KubeConfig } from './config';
 
 export class Watch {

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
-// import { anything, capture, instance, mock, spy, verify, when } from 'ts-mockito';
-
 import nock = require('nock');
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 import { KubeConfig } from './config';
 import { Cluster, Context, User } from './config_types';
 import { Watch } from './watch';
-import { IncomingMessage } from 'http';
+import { IncomingMessage } from 'node:http';
 
 const server = 'http://foo.company.com';
 

--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -1,5 +1,5 @@
 import WebSocket = require('isomorphic-ws');
-import stream = require('stream');
+import stream = require('node:stream');
 
 import { V1Status } from './api';
 import { KubeConfig } from './config';

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream';
-import { promisify } from 'util';
+import { setImmediate as setImmediatePromise } from 'node:timers/promises';
 import { expect } from 'chai';
 import WebSocket = require('isomorphic-ws');
 import { WritableStreamBuffer } from 'stream-buffers';
@@ -8,8 +8,6 @@ import { V1Status } from './api';
 import { KubeConfig } from './config';
 import { Cluster, Context, User } from './config_types';
 import { WebSocketHandler } from './web-socket-handler';
-
-const setImmediatePromise = promisify(setImmediate);
 
 describe('WebSocket', () => {
     it('should throw on unknown code', () => {

--- a/test/call-awaiter.ts
+++ b/test/call-awaiter.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 export class CallAwaiter extends EventEmitter {
   public awaitCall(event: string) {

--- a/test/match-buffer.ts
+++ b/test/match-buffer.ts
@@ -1,6 +1,5 @@
-import { deepStrictEqual } from 'assert';
 import { expect } from 'chai';
-import { RequestOptions, Agent } from 'https';
+import { RequestOptions, Agent } from 'node:https';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 
 export function matchBuffer(channel: number, contents: string): StringBufferMatcher {


### PR DESCRIPTION
This commit is a first pass at cleaning up the imports in the project. It moves to the 'node:' scheme for core modules, removes some unnecessary imports, and removes some unused imports.

Refs: https://github.com/kubernetes-client/javascript/issues/1907