### PR TITLE
refactor imports in src

### DIFF
--- a/src/attach.ts
+++ b/src/attach.ts
@@ -1,6 +1,6 @@
-import WebSocket = require('isomorphic-ws');
-import querystring = require('node:querystring');
-import stream = require('node:stream');
+import WebSocket from 'isomorphic-ws';
+import querystring from 'node:querystring';
+import stream from 'node:stream';
 
 import { KubeConfig } from './config';
 import { isResizable, ResizableStream, TerminalSizeQueue } from './terminal-size-queue';

--- a/src/attach_test.ts
+++ b/src/attach_test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import WebSocket = require('isomorphic-ws');
+import WebSocket from 'isomorphic-ws';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
-import https = require('node:https');
+import https from 'node:https';
 
 import { User } from './config_types';
-import WebSocket = require('isomorphic-ws');
+import WebSocket from 'isomorphic-ws';
 
 export interface Authenticator {
     isAuthProvider(user: User): boolean;

--- a/src/azure_auth.ts
+++ b/src/azure_auth.ts
@@ -1,6 +1,6 @@
-import * as proc from 'node:child_process';
-import https = require('node:https');
-import * as jsonpath from 'jsonpath-plus';
+import proc from 'node:child_process';
+import https from 'node:https';
+import jsonpath from 'jsonpath-plus';
 
 import { Authenticator } from './auth';
 import { User } from './config_types';

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -1,7 +1,7 @@
 import { expect, use } from 'chai';
-import chaiAsPromised = require('chai-as-promised');
+import chaiAsPromised from 'chai-as-promised';
 
-import * as mock from 'ts-mockito';
+import mock from 'ts-mockito';
 
 import { V1ListMeta, V1Namespace, V1NamespaceList, V1ObjectMeta, V1Pod } from './api';
 import { deleteItems, deleteObject, ListWatch } from './cache';
@@ -11,7 +11,7 @@ import { ListPromise } from './informer';
 
 use(chaiAsPromised);
 
-import nock = require('nock');
+import nock from 'nock';
 import { Watch } from './watch';
 
 const server = 'http://foo.company.com';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,11 @@
-import fs = require('node:fs');
-import https = require('node:https');
-import yaml = require('js-yaml');
-import net = require('node:net');
-import path = require('node:path');
+import fs from 'node:fs';
+import https from 'node:https';
+import yaml from 'js-yaml';
+import net from 'node:net';
+import path from 'node:path';
 
 import { Headers, RequestInit } from 'node-fetch';
-import * as api from './api';
+import { RequestContext } from './api';
 import { Authenticator } from './auth';
 import { AzureAuth } from './azure_auth';
 import {
@@ -31,8 +31,8 @@ import {
     ServerConfiguration,
 } from './gen';
 import { OpenIDConnectAuth } from './oidc_auth';
-import WebSocket = require('isomorphic-ws');
-import child_process = require('node:child_process');
+import WebSocket from 'isomorphic-ws';
+import child_process from 'node:child_process';
 
 const SERVICEACCOUNT_ROOT: string = '/var/run/secrets/kubernetes.io/serviceaccount';
 const SERVICEACCOUNT_CA_PATH: string = SERVICEACCOUNT_ROOT + '/ca.crt';
@@ -212,7 +212,7 @@ export class KubeConfig implements SecurityAuthentication {
      * Applies SecurityAuthentication to RequestContext of an API Call from API Client
      * @param context
      */
-    public async applySecurityAuthentication(context: api.RequestContext): Promise<void> {
+    public async applySecurityAuthentication(context: RequestContext): Promise<void> {
         const cluster = this.getCurrentCluster();
         const user = this.getCurrentUser();
 

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,12 +1,11 @@
 import { readFileSync } from 'node:fs';
-import * as https from 'node:https';
+import https from 'node:https';
 import { Agent, RequestOptions } from 'node:https';
-import { join } from 'node:path';
+import path, { join } from 'node:path';
 
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import mockfs = require('mock-fs');
-import * as path from 'node:path';
+import mockfs from 'mock-fs';
 
 import { Headers } from 'node-fetch';
 import { HttpMethod } from '.';

--- a/src/config_types.ts
+++ b/src/config_types.ts
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs';
+import fs from 'node:fs';
 
 export enum ActionOnInvalid {
     THROW = 'throw',

--- a/src/cp.ts
+++ b/src/cp.ts
@@ -1,7 +1,7 @@
-import * as fs from 'node:fs';
+import fs from 'node:fs';
 import { WritableStreamBuffer } from 'stream-buffers';
 import * as tar from 'tar';
-import * as tmp from 'tmp-promise';
+import tmp from 'tmp-promise';
 
 import { KubeConfig } from './config';
 import { Exec } from './exec';

--- a/src/cp_test.ts
+++ b/src/cp_test.ts
@@ -1,6 +1,6 @@
 import { anything, anyFunction, instance, mock, verify, when } from 'ts-mockito';
-import * as querystring from 'node:querystring';
-import WebSocket = require('isomorphic-ws');
+import querystring from 'node:querystring';
+import WebSocket from 'isomorphic-ws';
 
 import { CallAwaiter } from '../test';
 import { KubeConfig } from './config';

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,6 +1,6 @@
-import WebSocket = require('isomorphic-ws');
-import querystring = require('node:querystring');
-import stream = require('stream');
+import WebSocket from 'isomorphic-ws';
+import querystring from 'node:querystring';
+import stream from 'stream';
 
 import { V1Status } from './api';
 import { KubeConfig } from './config';

--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -1,10 +1,10 @@
 import { OutgoingHttpHeaders } from 'node:http';
-import https = require('node:https');
+import https from 'node:https';
 
 import { Authenticator } from './auth';
 import { User } from './config_types';
 
-import child_process = require('node:child_process');
+import child_process from 'node:child_process';
 
 export interface CredentialStatus {
     readonly token: string;

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -9,7 +9,7 @@ import { ExecAuth } from './exec_auth';
 import { User } from './config_types';
 import { fail } from 'node:assert';
 
-import child_process = require('node:child_process');
+import child_process from 'node:child_process';
 
 describe('ExecAuth', () => {
     it('should claim correctly', () => {

--- a/src/file_auth.ts
+++ b/src/file_auth.ts
@@ -1,5 +1,5 @@
-import fs = require('node:fs');
-import https = require('node:https');
+import fs from 'node:fs';
+import https from 'node:https';
 
 import { Authenticator } from './auth';
 import { User } from './config_types';

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -1,6 +1,6 @@
-import * as proc from 'node:child_process';
-import https = require('node:https');
-import * as jsonpath from 'jsonpath-plus';
+import proc from 'node:child_process';
+import https from 'node:https';
+import jsonpath from 'jsonpath-plus';
 
 import { Authenticator } from './auth';
 import { User } from './config_types';

--- a/src/integration_test.ts
+++ b/src/integration_test.ts
@@ -1,6 +1,6 @@
 import { expect, use } from 'chai';
-import chaiAsPromised = require('chai-as-promised');
-import nock = require('nock');
+import chaiAsPromised from 'chai-as-promised';
+import nock from 'nock';
 
 import { CoreV1Api } from './api';
 import { KubeConfig } from './config';

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -1,6 +1,6 @@
 import { fail } from 'node:assert';
 import { expect } from 'chai';
-import nock = require('nock');
+import nock from 'nock';
 import { KubeConfig } from './config';
 import { V1Status, ApiException } from './gen';
 import { Metrics, NodeMetricsList, PodMetricsList } from './metrics';

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1,6 +1,6 @@
 import { fail } from 'node:assert';
 import { expect } from 'chai';
-import nock = require('nock');
+import nock from 'nock';
 import { Configuration, V1APIResource, V1APIResourceList, V1Secret } from './api';
 import { KubeConfig } from './config';
 import { KubernetesObjectApi } from './object';

--- a/src/portforward.ts
+++ b/src/portforward.ts
@@ -1,6 +1,6 @@
-import WebSocket = require('isomorphic-ws');
-import querystring = require('node:querystring');
-import stream = require('node:stream');
+import WebSocket from 'isomorphic-ws';
+import querystring from 'node:querystring';
+import stream from 'node:stream';
 
 import { KubeConfig } from './config';
 import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';

--- a/src/proto-client.ts
+++ b/src/proto-client.ts
@@ -1,4 +1,4 @@
-import http = require('node:http');
+import http from 'node:http';
 
 import { KubeConfig } from './config';
 

--- a/src/top_test.ts
+++ b/src/top_test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import nock = require('nock');
+import nock from 'nock';
 import { KubeConfig } from './config';
 import { Metrics, PodMetricsList } from './metrics';
 import { topPods } from './top';

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import nock = require('nock');
+import nock from 'nock';
 import { PassThrough } from 'node:stream';
 import { KubeConfig } from './config';
 import { Cluster, Context, User } from './config_types';

--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -1,5 +1,5 @@
-import WebSocket = require('isomorphic-ws');
-import stream = require('node:stream');
+import WebSocket from 'isomorphic-ws';
+import stream from 'node:stream';
 
 import { V1Status } from './api';
 import { KubeConfig } from './config';

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'node:stream';
 import { setImmediate as setImmediatePromise } from 'node:timers/promises';
 import { expect } from 'chai';
-import WebSocket = require('isomorphic-ws');
+import WebSocket from 'isomorphic-ws';
 import { WritableStreamBuffer } from 'stream-buffers';
 
 import { V1Status } from './api';

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,4 +1,4 @@
-import * as yaml from 'js-yaml';
+import yaml from 'js-yaml';
 
 export function loadYaml<T>(data: string, opts?: yaml.LoadOptions): T {
     return yaml.load(data, opts) as any as T;


### PR DESCRIPTION
This commit uses `import` instead of `require()` in all cases, except when importing JSON files. It also removes a number of '* as' imports that appear to be unnecessary.

A few notes:
- All of the dependencies changed here seem to have a default export except for `tar`, so you'll still see `* as tar` in one place in the code.
- I haven't touched the examples yet because there are still a few issues that need to be figured out.
  - To use `@kubernetes/client-node` or `dist`?
  - To move to ESM the files with a `.js` extension probably won't run directly. Is this OK, or should they be renamed to `.mjs`?
  - It would be nice to be able to refactor `import * as k8s from` to just `import k8s from`, but I think some work would be necessary to add a default export.