### PR TITLE
ci: set github token permission to write in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
In response to #1926 - the release to npm did work but the git-tagging wasn't successful so I did that manually.
I suspect missing github token permissions, this __should__ fix the issue, but I did not test it to be honest.

If we see this working, I can create a PR for the `release-1.x` branch.