### PR TITLE
override whatwg-url dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,6 +2012,14 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/punycode.js": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -2435,9 +2443,15 @@
             }
         },
         "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "dependencies": {
+                "punycode": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/ts-mockito": {
             "version": "2.6.1",
@@ -2649,17 +2663,23 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
             "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "tr46": "^4.1.1",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/workerpool": {
@@ -4224,7 +4244,7 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
             "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
             "requires": {
-                "whatwg-url": "^5.0.0"
+                "whatwg-url": "12.0.1"
             }
         },
         "normalize-path": {
@@ -4346,6 +4366,11 @@
             "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
             "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
             "dev": true
+        },
+        "punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "punycode.js": {
             "version": "2.3.1",
@@ -4652,9 +4677,12 @@
             }
         },
         "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "requires": {
+                "punycode": "^2.3.0"
+            }
         },
         "ts-mockito": {
             "version": "2.6.1",
@@ -4816,17 +4844,17 @@
             }
         },
         "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
             "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "tr46": "^4.1.1",
+                "webidl-conversions": "^7.0.0"
             }
         },
         "workerpool": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
         "arrowParens": "always"
     },
     "overrides": {
-        "colors": "1.4.0"
+        "colors": "1.4.0",
+        "whatwg-url@<12.0.1": "12.0.1"
     }
 }


### PR DESCRIPTION
The generated client on the release-1.x branch relies on the node-fetch@2.x module, which depends on whatwg-url@5.0.0, which uses the Node core punycode module. Node's punycode module was runtime deprecated in v21, which causes this module to print a deprecation warning when used on newer versions of Node.

whatwg-url@9.0.0 stopped using punycode directly, but continued to use it indirectly via its own tr46 dependency. The problematic use of punycode was finally removed in whatwg-url@12.0.1.

node-fetch@2.x claims backwards compatibility to Node v4, but the fixed version of whatwg-url only claims compatibility back to Node 12. For this reason, the node-fetch project has stated that they will not address this issue. For reference, Node v4 went EOL in 2018, and Node v12 when EOL in early 2022. Node 18 is currently the oldest supported version, and Node v23 was released this week.

Ideally, the generator will move to a newer version of node-fetch, native fetch, or even the undici module that implements fetch in core. Until that happens, this module can override whatwg-url and silence the deprecation warning.

It's also worth noting that this punycode deprecation is not the same one as the punycode deprecation on the master branch.

This change has been tested locally on v18.0.0.

Refs: https://github.com/nodejs/node/pull/47202
Refs: https://github.com/node-fetch/node-fetch/pull/1793

(Sorry for the excessive commit message, but there is a lot of context to capture and maybe it will help someone looking through the git history one day.)