### PR TITLE
Don't concatenate shell arguments.

### DIFF
--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -66,7 +66,14 @@ export class GoogleCloudPlatformAuth implements Authenticator {
         if (!cmd) {
             throw new Error('Token is expired!');
         }
-        const args = config['cmd-args'] ? config['cmd-args'].split(' ') : [];
+        const args = (config['cmd-args'] ? config['cmd-args'].split(' ') : []).map(
+            (arg: string): string => {
+                if (arg[0] == '\'' || arg[0] == '"') {
+                    return arg.substring(1, arg.length-1);
+                }
+                return arg;
+            }
+        );
         // TODO: Cache to file?
         // TODO: do this asynchronously
         let output: any;

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -62,18 +62,16 @@ export class GoogleCloudPlatformAuth implements Authenticator {
     }
 
     private updateAccessToken(config: Config): void {
-        let cmd = config['cmd-path'];
+        const cmd = config['cmd-path'];
         if (!cmd) {
             throw new Error('Token is expired!');
         }
-        const args = (config['cmd-args'] ? config['cmd-args'].split(' ') : []).map(
-            (arg: string): string => {
-                if (arg[0] == '\'' || arg[0] == '"') {
-                    return arg.substring(1, arg.length-1);
-                }
-                return arg;
+        const args = (config['cmd-args'] ? config['cmd-args'].split(' ') : []).map((arg: string): string => {
+            if (arg[0] === "'" || arg[0] === '"') {
+                return arg.substring(1, arg.length - 1);
             }
-        );
+            return arg;
+        });
         // TODO: Cache to file?
         // TODO: do this asynchronously
         let output: any;

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -83,10 +83,6 @@ export class GoogleCloudPlatformAuth implements Authenticator {
             throw new Error('Failed to refresh token: ' + (err as Error).message);
         }
 
-        // remove leading and trailing `'` from the output
-        output = output.toString();
-        output = output.replace(/'/g, '');
-        output = output.replace(/\'$/, '');
         const resultObj = JSON.parse(output);
 
         const tokenPathKeyInConfig = config['token-key'];

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -66,17 +66,13 @@ export class GoogleCloudPlatformAuth implements Authenticator {
         if (!cmd) {
             throw new Error('Token is expired!');
         }
-        // Wrap cmd in quotes to make it cope with spaces in path
-        cmd = `"${cmd}"`;
-        const args = config['cmd-args'];
-        if (args) {
-            cmd = cmd + ' ' + args;
-        }
+        const cmdPath = config['cmd-path'];
+        const args = config['cmd-args'] ? config['cmd-args'].split(' ') : [];
         // TODO: Cache to file?
         // TODO: do this asynchronously
         let output: any;
         try {
-            output = proc.execSync(cmd);
+            output = proc.execFileSync(cmdPath, args);
         } catch (err) {
             throw new Error('Failed to refresh token: ' + (err as Error).message);
         }

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -76,6 +76,10 @@ export class GoogleCloudPlatformAuth implements Authenticator {
             throw new Error('Failed to refresh token: ' + (err as Error).message);
         }
 
+        // remove leading and trailing `'` from the output
+        output = output.toString();
+        output = output.replace(/'/g, '');
+        output = output.replace(/\'$/, '');
         const resultObj = JSON.parse(output);
 
         const tokenPathKeyInConfig = config['token-key'];

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -66,13 +66,12 @@ export class GoogleCloudPlatformAuth implements Authenticator {
         if (!cmd) {
             throw new Error('Token is expired!');
         }
-        const cmdPath = config['cmd-path'];
         const args = config['cmd-args'] ? config['cmd-args'].split(' ') : [];
         // TODO: Cache to file?
         // TODO: do this asynchronously
         let output: any;
         try {
-            output = proc.execFileSync(cmdPath, args);
+            output = proc.execFileSync(cmd, args);
         } catch (err) {
             throw new Error('Failed to refresh token: ' + (err as Error).message);
         }


### PR DESCRIPTION
Fixes [https://github.com/kubernetes-client/javascript/security/code-scanning/17](https://github.com/kubernetes-client/javascript/security/code-scanning/17)

To fix the problem, we should avoid using `proc.execSync` with a dynamically constructed command string. Instead, we can use `child_process.execFileSync`, which takes the command and its arguments as separate parameters, thus avoiding shell interpretation of the arguments. This change will ensure that the arguments are passed safely to the command without the risk of command injection.

**Steps to fix:**
1. Replace the use of `proc.execSync` with `proc.execFileSync`.
2. Split the command and its arguments into separate parameters for `execFileSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
