### PR TITLE
test: clean up rejection and fail logic

### DIFF
--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -7,7 +7,6 @@ import { OutgoingHttpHeaders } from 'node:http';
 
 import { ExecAuth } from './exec_auth';
 import { User } from './config_types';
-import { fail } from 'node:assert';
 
 import child_process from 'node:child_process';
 
@@ -336,10 +335,6 @@ describe('ExecAuth', () => {
             },
             opts,
         );
-        if (!opts.headers) {
-            fail('unexpected null headers!');
-        } else {
-            expect(opts.headers.Authorization).to.equal('Bearer foo');
-        }
+        expect(opts.headers?.Authorization).to.equal('Bearer foo');
     });
 });

--- a/src/portforward_test.ts
+++ b/src/portforward_test.ts
@@ -123,17 +123,11 @@ describe('PortForward', () => {
         const osStream = new WritableStreamBuffer();
         const isStream = new ReadableStreamBuffer();
 
-        try {
-            await portForward.portForward('ns', 'pod', [], osStream, osStream, isStream);
-            expect(false, 'should have thrown').to.equal(true);
-        } catch (err: any) {
-            expect(err.toString()).to.equal('Error: You must provide at least one port to forward to.');
-        }
-        try {
-            await portForward.portForward('ns', 'pod', [1, 2], osStream, osStream, isStream);
-            expect(false, 'should have thrown').to.equal(true);
-        } catch (err: any) {
-            expect(err.toString()).to.equal('Error: Only one port is currently supported for port-forward');
-        }
+        await expect(
+            portForward.portForward('ns', 'pod', [], osStream, osStream, isStream),
+        ).to.be.rejectedWith(Error, 'You must provide at least one port to forward to.');
+        await expect(
+            portForward.portForward('ns', 'pod', [1, 2], osStream, osStream, isStream),
+        ).to.be.rejectedWith(Error, 'Only one port is currently supported for port-forward');
     });
 });

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -134,13 +134,7 @@ describe('WebSocket', () => {
             target: mockWs,
         });
 
-        let rejected = false;
-        try {
-            const val = await promise;
-        } catch (err) {
-            rejected = true;
-        }
-        expect(rejected).to.equal(true);
+        await expect(promise).to.be.rejected;
     });
     it('should connect properly', async () => {
         const kc = new KubeConfig();


### PR DESCRIPTION
This commit updates the tests to remove hand rolled logic for tracking rejections and failure cases. The previous logic is replaced with features built into the assertion module.

This uncovered at least one test that was not working as expected, and makes the code shorter and (IMO) more readable.