### PR TITLE
Add write permissions to deploy docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: write
 jobs:
   build-and-deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixing #2023, based on the [repo](https://github.com/JamesIves/github-pages-deploy-action/issues/1285) for the action.

> GitHub changed new repository default settings and made [workflow permissions read-only by default](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/). The fix was to add write permissions to the workflow:
```
permissions:
  contents: write
```