### PR TITLE
chore: bump jsonpath-plus allowed version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "byline": "^5.0.0",
                 "isomorphic-ws": "^5.0.0",
                 "js-yaml": "^4.1.0",
-                "jsonpath-plus": "^10.1.0",
+                "jsonpath-plus": "^10.2.0",
                 "request": "^2.88.0",
                 "rfc4648": "^1.3.0",
                 "stream-buffers": "^3.0.2",
@@ -2855,6 +2855,7 @@
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
             "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+            "license": "MIT",
             "dependencies": {
                 "@jsep-plugin/assignment": "^1.3.0",
                 "@jsep-plugin/regex": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "byline": "^5.0.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.1.0",
+        "jsonpath-plus": "^10.2.0",
         "request": "^2.88.0",
         "rfc4648": "^1.3.0",
         "stream-buffers": "^3.0.2",


### PR DESCRIPTION
we are getting more and more reports about this as we allow a version where this CVE exists.
This should silent these reports :) 