### PR TITLE
chore: bump jsonpath-plus allowed version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "form-data": "^4.0.0",
                 "isomorphic-ws": "^5.0.0",
                 "js-yaml": "^4.1.0",
-                "jsonpath-plus": "^10.0.0",
+                "jsonpath-plus": "^10.2.0",
                 "node-fetch": "^2.6.9",
                 "openid-client": "^6.1.3",
                 "rfc4648": "^1.3.0",
@@ -1826,6 +1826,7 @@
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
             "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+            "license": "MIT",
             "dependencies": {
                 "@jsep-plugin/assignment": "^1.3.0",
                 "@jsep-plugin/regex": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "form-data": "^4.0.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.0.0",
+        "jsonpath-plus": "^10.2.0",
         "node-fetch": "^2.6.9",
         "openid-client": "^6.1.3",
         "rfc4648": "^1.3.0",


### PR DESCRIPTION
Same as #2031 but for release-1.x.