### PR TITLE
Add Health class to call health check endpoints on current context

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch';
-import { AbortSignal } from 'node-fetch/externals';
 import { KubeConfig } from './config';
 import { RequestOptions } from 'node:https';
 
@@ -30,8 +29,9 @@ export class Health {
 
         const requestURL = new URL(cluster.server + path);
         const requestInit = await this.config.applyToFetchOptions(opts);
-        const controller = new AbortController();
-        requestInit.signal = controller.signal as AbortSignal;
+        if (opts.signal) {
+            requestInit.signal = opts.signal;
+        }
         requestInit.method = 'GET';
 
         try {

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,6 +1,5 @@
 import fetch from 'node-fetch';
 import { AbortSignal } from 'node-fetch/externals';
-import { URL } from 'url';
 import { KubeConfig } from './config';
 import { RequestOptions } from 'node:https';
 

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,57 @@
+import fetch from 'node-fetch';
+import { AbortSignal } from 'node-fetch/externals';
+import { URL } from 'url';
+import { KubeConfig } from './config';
+import { RequestOptions } from 'https';
+
+export class Health {
+    public config: KubeConfig;
+
+    public constructor(config: KubeConfig) {
+        this.config = config;
+    }
+
+    public async readyz(opts: RequestOptions): Promise<boolean> {
+        return this.check('/readyz', opts);
+    }
+
+    public async livez(opts: RequestOptions): Promise<boolean> {
+        return this.check('/livez', opts);
+    }
+
+    private async healthz(opts: RequestOptions): Promise<boolean> {
+        return this.check('/healthz', opts);
+    }
+
+    private async check(path: string, opts: RequestOptions): Promise<boolean> {
+        const cluster = this.config.getCurrentCluster();
+        if (!cluster) {
+            throw new Error('No currently active cluster');
+        }
+
+        const requestURL = new URL(cluster.server + path);
+        const requestInit = await this.config.applyToFetchOptions(opts);
+        const controller = new AbortController();
+        requestInit.signal = controller.signal as AbortSignal;
+        requestInit.method = 'GET';
+
+        return await fetch(requestURL.toString(), requestInit)
+            .then((response) => {
+                const status = response.status;
+                if (status === 200) {
+                    return true;
+                } else if (status === 404) {
+                    if (path === '/healthz') {
+                        // /livez/readyz return 404 and healthz also returns 404, let's consider it is live
+                        return true;
+                    }
+                    return this.healthz(opts);
+                } else {
+                    return false;
+                }
+            })
+            .catch((err) => {
+                return false;
+            });
+    }
+}

--- a/src/health.ts
+++ b/src/health.ts
@@ -39,17 +39,17 @@ export class Health {
             const status = response.status;
             if (status === 200) {
                 return true;
-            } else if (status === 404) {
+            }
+            if (status === 404) {
                 if (path === '/healthz') {
                     // /livez/readyz return 404 and healthz also returns 404, let's consider it is live
                     return true;
                 }
                 return this.healthz(opts);
-            } else {
-                return false;
             }
-        } catch {
             return false;
+        } catch {
+            throw new Error('Error occurred in health request');
         }
     }
 }

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import fetch, { AbortError } from 'node-fetch';
 import { KubeConfig } from './config';
 import { RequestOptions } from 'node:https';
 
@@ -48,7 +48,10 @@ export class Health {
                 return this.healthz(opts);
             }
             return false;
-        } catch {
+        } catch (err: unknown) {
+            if (err instanceof Error && err.name === 'AbortError') {
+                throw err;
+            }
             throw new Error('Error occurred in health request');
         }
     }

--- a/src/health_test.ts
+++ b/src/health_test.ts
@@ -1,0 +1,127 @@
+import { expect } from 'chai';
+import nock from 'nock';
+
+import { KubeConfig } from './config';
+import { Health } from './health';
+import { Cluster, User } from './config_types';
+
+describe('Health', () => {
+    describe('livez', () => {
+        it('should throw an error if no current active cluster', async () => {
+            const kc = new KubeConfig();
+            const health = new Health(kc);
+            await expect(health.livez({})).to.be.rejectedWith('No currently active cluster');
+        });
+
+        it('should return true if /livez returns with status 200', async () => {
+            const kc = new KubeConfig();
+            const cluster = {
+                name: 'foo',
+                server: 'https://server.com',
+            } as Cluster;
+
+            const user = {
+                name: 'my-user',
+                password: 'some-password',
+            } as User;
+            kc.loadFromClusterAndUser(cluster, user);
+
+            const scope = nock('https://server.com').get('/livez').reply(200);
+            const health = new Health(kc);
+
+            const r = await health.livez({});
+            expect(r).to.be.true;
+            scope.done();
+        });
+
+        it('should return false if /livez returns with status 500', async () => {
+            const kc = new KubeConfig();
+            const cluster = {
+                name: 'foo',
+                server: 'https://server.com',
+            } as Cluster;
+
+            const user = {
+                name: 'my-user',
+                password: 'some-password',
+            } as User;
+            kc.loadFromClusterAndUser(cluster, user);
+
+            const scope = nock('https://server.com').get('/livez').reply(500);
+            const health = new Health(kc);
+
+            const r = await health.livez({});
+            expect(r).to.be.false;
+            scope.done();
+        });
+
+        it('should return true if /livez returns status 404 and /healthz returns status 200', async () => {
+            const kc = new KubeConfig();
+            const cluster = {
+                name: 'foo',
+                server: 'https://server.com',
+            } as Cluster;
+
+            const user = {
+                name: 'my-user',
+                password: 'some-password',
+            } as User;
+            kc.loadFromClusterAndUser(cluster, user);
+
+            const scope = nock('https://server.com');
+            scope.get('/livez').reply(404);
+            scope.get('/healthz').reply(200);
+            const health = new Health(kc);
+
+            const r = await health.livez({});
+            expect(r).to.be.true;
+            scope.done();
+        });
+
+        it('should return false if /livez returns status 404 and /healthz returns status 500', async () => {
+            const kc = new KubeConfig();
+            const cluster = {
+                name: 'foo',
+                server: 'https://server.com',
+            } as Cluster;
+
+            const user = {
+                name: 'my-user',
+                password: 'some-password',
+            } as User;
+            kc.loadFromClusterAndUser(cluster, user);
+
+            const scope = nock('https://server.com');
+            scope.get('/livez').reply(404);
+            scope.get('/healthz').reply(500);
+            const health = new Health(kc);
+
+            const r = await health.livez({});
+            expect(r).to.be.false;
+            scope.done();
+        });
+
+        it('should return true if both /livez and /healthz return status 404', async () => {
+            const kc = new KubeConfig();
+            const cluster = {
+                name: 'foo',
+                server: 'https://server.com',
+            } as Cluster;
+
+            const user = {
+                name: 'my-user',
+                password: 'some-password',
+            } as User;
+            kc.loadFromClusterAndUser(cluster, user);
+
+            const scope = nock('https://server.com');
+            scope.get('/livez').reply(404);
+            scope.get('/healthz').reply(200);
+            const health = new Health(kc);
+
+            const r = await health.livez({});
+            expect(r).to.be.true;
+            scope.done();
+        });
+    });
+});

--- a/src/health_test.ts
+++ b/src/health_test.ts
@@ -123,5 +123,27 @@ describe('Health', () => {
             expect(r).to.be.true;
             scope.done();
         });
+
+        it('should return false when fetch throws an error', async () => {
+            const kc = new KubeConfig();
+            const cluster = {
+                name: 'foo',
+                server: 'https://server.com',
+            } as Cluster;
+
+            const user = {
+                name: 'my-user',
+                password: 'some-password',
+            } as User;
+            kc.loadFromClusterAndUser(cluster, user);
+
+            const scope = nock('https://server.com');
+            scope.get('/livez').replyWithError(new Error('an error'));
+            const health = new Health(kc);
+
+            const r = await health.livez({});
+            expect(r).to.be.false;
+            scope.done();
+        });
     });
 });

--- a/src/health_test.ts
+++ b/src/health_test.ts
@@ -124,7 +124,7 @@ describe('Health', () => {
             scope.done();
         });
 
-        it('should return false when fetch throws an error', async () => {
+        it('should throw an error when fetch throws an error', async () => {
             const kc = new KubeConfig();
             const cluster = {
                 name: 'foo',
@@ -141,8 +141,7 @@ describe('Health', () => {
             scope.get('/livez').replyWithError(new Error('an error'));
             const health = new Health(kc);
 
-            const r = await health.livez({});
-            expect(r).to.be.false;
+            await expect(health.livez({})).to.be.rejectedWith('Error occurred in health request');
             scope.done();
         });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './cp';
 export * from './patch';
 export * from './metrics';
 export * from './object';
+export * from './health';
 export { ConfigOptions, User, Cluster, Context } from './config_types';
 
 // Export AbortError and FetchError so that instanceof checks in user code will definitely use the same instances


### PR DESCRIPTION
Add an Health class with 2 public methods `livez` and `readyz` to check the health check endpoints of the current context.

If these endpoints are not served (status 404), the deprecated `healthz` is checked. If this endpoint `healthz` is also not served (status 404), the cluster is considered healthy, else its result is used.

