### PR TITLE
update deprecated husky command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "generate": "./generate-client.sh",
         "watch": "tsc --watch",
         "test": "c8 mocha",
-        "prepare": "npm run build && husky install",
+        "prepare": "npm run build && husky",
         "prepack": "npm run build",
         "docs": "typedoc src/gen/api"
     },


### PR DESCRIPTION
The husky install command is deprecated and prints a message saying so. This commit updates the command according to https://github.com/typicode/husky/issues/1415.