### PR TITLE
makes exec_auth spawn the command asynchronously

### DIFF
--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -109,17 +109,16 @@ export class ExecAuth implements Authenticator {
             subprocess.stdout.setEncoding('utf8');
             subprocess.stderr.setEncoding('utf8');
 
-            subprocess.stdout.on('data', (data: Buffer | string) => {
-                stdoutData += data.toString('utf8');
+            subprocess.stdout.on('data', (data: string) => {
+                stdoutData += data;
             });
 
-            subprocess.stderr.on('data', (data) => {
-                stderrData += data.toString('utf8');
+            subprocess.stderr.on('data', (data: string) => {
+                stderrData += data;
             });
 
             subprocess.on('error', (error) => {
                 savedError = error;
-                throw error;
             });
 
             subprocess.on('close', (code) => {

--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -20,10 +20,10 @@ export interface Credential {
 export class ExecAuth implements Authenticator {
     private readonly tokenCache: { [key: string]: Credential | null } = {};
     private execFn: (
-        cmd: string,
-        args: string[],
-        opts: child_process.SpawnOptions,
-    ) => child_process.SpawnSyncReturns<Buffer> = child_process.spawnSync;
+        command: string,
+        args?: readonly string[],
+        options?: child_process.SpawnOptionsWithoutStdio,
+    ) => child_process.ChildProcessWithoutNullStreams = child_process.spawn;
 
     public isAuthProvider(user: User): boolean {
         if (!user) {
@@ -41,7 +41,7 @@ export class ExecAuth implements Authenticator {
     }
 
     public async applyAuthentication(user: User, opts: https.RequestOptions): Promise<void> {
-        const credential = this.getCredential(user);
+        const credential = await this.getCredential(user);
         if (!credential) {
             return;
         }
@@ -70,7 +70,7 @@ export class ExecAuth implements Authenticator {
         return null;
     }
 
-    private getCredential(user: User): Credential | null {
+    private async getCredential(user: User): Promise<Credential | null> {
         // TODO: Add a unit test for token caching.
         const cachedToken = this.tokenCache[user.name];
         if (cachedToken) {
@@ -99,15 +99,33 @@ export class ExecAuth implements Authenticator {
             exec.env.forEach((elt) => (env[elt.name] = elt.value));
             opts = { ...opts, env };
         }
-        const result = this.execFn(exec.command, exec.args, opts);
-        if (result.error) {
-            throw result.error;
-        }
-        if (result.status === 0) {
-            const obj = JSON.parse(result.stdout.toString('utf8')) as Credential;
-            this.tokenCache[user.name] = obj;
-            return obj;
-        }
-        throw new Error(result.stderr.toString('utf8'));
+
+        return new Promise((accept, reject) => {
+            let stdoutData: string = '';
+            let stderrData: string = '';
+
+            const subprocess = this.execFn(exec.command, exec.args, opts);
+
+            subprocess.stdout.on('data', (data: Buffer | string) => {
+                stdoutData += data.toString('utf8');
+            });
+
+            subprocess.stderr.on('data', (data) => {
+                stderrData += data.toString('utf8');
+            });
+
+            subprocess.on('error', (error) => {
+                throw error;
+            });
+
+            subprocess.on('close', (code) => {
+                if (code !== 0) {
+                    throw new Error(stderrData);
+                }
+                const obj = JSON.parse(stdoutData) as Credential;
+                this.tokenCache[user.name] = obj;
+                accept(obj);
+            });
+        });
     }
 }

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -65,11 +65,13 @@ describe('ExecAuth', () => {
         ): child_process.ChildProcessWithoutNullStreams => {
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(Buffer.from(JSON.stringify({ status: { token: 'foo' } })));
                     },
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: () => {},
                 },
                 on: (op: string, f: any) => {
@@ -110,6 +112,7 @@ describe('ExecAuth', () => {
         ): child_process.ChildProcessWithoutNullStreams => {
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(
                             Buffer.from(
@@ -121,6 +124,7 @@ describe('ExecAuth', () => {
                     },
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: () => {},
                 },
                 on: (op: string, f: any) => {
@@ -168,6 +172,7 @@ describe('ExecAuth', () => {
             execCount++;
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(
                             Buffer.from(
@@ -179,6 +184,7 @@ describe('ExecAuth', () => {
                     },
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: () => {},
                 },
                 on: (op: string, f: any) => {
@@ -253,9 +259,11 @@ describe('ExecAuth', () => {
         ): child_process.ChildProcessWithoutNullStreams => {
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {},
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: () => {},
                 },
                 on: (op: string, f: any) => {
@@ -297,11 +305,13 @@ describe('ExecAuth', () => {
         ): child_process.ChildProcessWithoutNullStreams => {
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(Buffer.from(JSON.stringify({ status: { token: 'foo' } })));
                     },
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(Buffer.from('Some error!'));
                     },
@@ -346,11 +356,13 @@ describe('ExecAuth', () => {
             optsOut = options;
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(Buffer.from(JSON.stringify({ status: { token: 'foo' } })));
                     },
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: () => {},
                 },
                 on: (op: string, f: any) => {
@@ -402,11 +414,13 @@ describe('ExecAuth', () => {
         ): child_process.ChildProcessWithoutNullStreams => {
             return {
                 stdout: {
+                    setEncoding: () => {},
                     on: (_data: string, f: (data: Buffer | string) => void) => {
                         f(Buffer.from(JSON.stringify({ status: { token: 'foo' } })));
                     },
                 },
                 stderr: {
+                    setEncoding: () => {},
                     on: () => {},
                 },
                 on: (op: string, f: any) => {


### PR DESCRIPTION
This PR makes exec_auth calls `spawn` instead of `spawnSync`.

This is cery useful for a GUI to continue working during the plugin is executed.

Fixes #2044 
