### PR TITLE
src: remove AbortSignal import

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch';
-import { AbortSignal } from 'node-fetch/externals';
 import { Writable } from 'node:stream';
 import { ApiException } from './api';
 import { KubeConfig } from './config';

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,6 +1,5 @@
 import { createInterface } from 'node:readline';
 import fetch from 'node-fetch';
-import { AbortSignal } from 'node-fetch/externals';
 import { KubeConfig } from './config';
 
 export class Watch {


### PR DESCRIPTION
`AbortSignal` is available globally in all supported versions of Node. These imports were causing problems when attempting to upgrade TypeScript settings because apparently `'node-fetch/externals'` exists in the types package, but not in the actual node-fetch module.