### PR TITLE
src: convert project from CJS to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "@kubernetes/client-node",
     "version": "1.0.0-rc7",
     "description": "NodeJS client for kubernetes",
+    "type": "module",
     "repository": {
         "type": "git",
         "url": "https://github.com/kubernetes-client/javascript.git"

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,1 +1,1 @@
-export * from './gen';
+export * from './gen/index.js';

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -2,9 +2,9 @@ import WebSocket from 'isomorphic-ws';
 import querystring from 'node:querystring';
 import stream from 'node:stream';
 
-import { KubeConfig } from './config';
-import { isResizable, ResizableStream, TerminalSizeQueue } from './terminal-size-queue';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { KubeConfig } from './config.js';
+import { isResizable, ResizableStream, TerminalSizeQueue } from './terminal-size-queue.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 export class Attach {
     public 'handler': WebSocketInterface;

--- a/src/attach_test.ts
+++ b/src/attach_test.ts
@@ -4,10 +4,10 @@ import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { CallAwaiter, matchBuffer, ResizableWriteableStreamBuffer } from '../test';
-import { Attach } from './attach';
-import { KubeConfig } from './config';
-import { TerminalSize } from './terminal-size-queue';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { Attach } from './attach.js';
+import { KubeConfig } from './config.js';
+import { TerminalSize } from './terminal-size-queue.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 describe('Attach', () => {
     describe('basic', () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,6 @@
 import https from 'node:https';
 
-import { User } from './config_types';
+import { User } from './config_types.js';
 import WebSocket from 'isomorphic-ws';
 
 export interface Authenticator {

--- a/src/azure_auth.ts
+++ b/src/azure_auth.ts
@@ -1,9 +1,9 @@
 import proc from 'node:child_process';
 import https from 'node:https';
-import jsonpath from 'jsonpath-plus';
+import * as jsonpath from 'jsonpath-plus';
 
-import { Authenticator } from './auth';
-import { User } from './config_types';
+import { Authenticator } from './auth.js';
+import { User } from './config_types.js';
 
 /* FIXME: maybe we can extend the User and User.authProvider type to have a proper type.
 Currently user.authProvider has `any` type and so we don't have a type for user.authProvider.config.

--- a/src/azure_auth_test.ts
+++ b/src/azure_auth_test.ts
@@ -2,10 +2,10 @@ import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { join } from 'node:path';
 
-import { User, Cluster } from './config_types';
-import { AzureAuth } from './azure_auth';
-import { KubeConfig } from './config';
-import { HttpMethod, RequestContext } from '.';
+import { User, Cluster } from './config_types.js';
+import { AzureAuth } from './azure_auth.js';
+import { KubeConfig } from './config.js';
+import { HttpMethod, RequestContext } from './index.js';
 
 use(chaiAsPromised);
 

--- a/src/azure_auth_test.ts
+++ b/src/azure_auth_test.ts
@@ -1,11 +1,14 @@
 import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { User, Cluster } from './config_types.js';
 import { AzureAuth } from './azure_auth.js';
 import { KubeConfig } from './config.js';
 import { HttpMethod, RequestContext } from './index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 use(chaiAsPromised);
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,10 +9,10 @@ import {
     ListPromise,
     ObjectCallback,
     UPDATE,
-} from './informer';
-import { KubernetesObject } from './types';
-import { ObjectSerializer } from './serializer';
-import { Watch } from './watch';
+} from './informer.js';
+import { KubernetesObject } from './types.js';
+import { ObjectSerializer } from './serializer.js';
+import { Watch } from './watch.js';
 
 export interface ObjectCache<T> {
     get(name: string, namespace?: string): T | undefined;

--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -3,16 +3,23 @@ import chaiAsPromised from 'chai-as-promised';
 
 import mock from 'ts-mockito';
 
-import { V1Namespace, V1NamespaceList, V1ObjectMeta, V1Pod, V1PodList, V1ListMeta } from './api';
-import { deleteObject, ListWatch, deleteItems, CacheMap, cacheMapFromList, addOrUpdateObject } from './cache';
-import { KubeConfig } from './config';
-import { Cluster, Context, User } from './config_types';
-import { ListPromise } from './informer';
+import { V1Namespace, V1NamespaceList, V1ObjectMeta, V1Pod, V1PodList, V1ListMeta } from './api.js';
+import {
+    deleteObject,
+    ListWatch,
+    deleteItems,
+    CacheMap,
+    cacheMapFromList,
+    addOrUpdateObject,
+} from './cache.js';
+import { KubeConfig } from './config.js';
+import { Cluster, Context, User } from './config_types.js';
+import { ListPromise } from './informer.js';
 
 use(chaiAsPromised);
 
 import nock from 'nock';
-import { Watch } from './watch';
+import { Watch } from './watch.js';
 
 const server = 'http://foo.company.com';
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,9 @@ import net from 'node:net';
 import path from 'node:path';
 
 import { Headers, RequestInit } from 'node-fetch';
-import { RequestContext } from './api';
-import { Authenticator } from './auth';
-import { AzureAuth } from './azure_auth';
+import { RequestContext } from './api.js';
+import { Authenticator } from './auth.js';
+import { AzureAuth } from './azure_auth.js';
 import {
     Cluster,
     ConfigOptions,
@@ -19,18 +19,18 @@ import {
     newContexts,
     newUsers,
     User,
-} from './config_types';
-import { ExecAuth } from './exec_auth';
-import { FileAuth } from './file_auth';
-import { GoogleCloudPlatformAuth } from './gcp_auth';
+} from './config_types.js';
+import { ExecAuth } from './exec_auth.js';
+import { FileAuth } from './file_auth.js';
+import { GoogleCloudPlatformAuth } from './gcp_auth.js';
 import {
     AuthMethodsConfiguration,
     Configuration,
     createConfiguration,
     SecurityAuthentication,
     ServerConfiguration,
-} from './gen';
-import { OpenIDConnectAuth } from './oidc_auth';
+} from './gen/index.js';
+import { OpenIDConnectAuth } from './oidc_auth.js';
 import WebSocket from 'isomorphic-ws';
 import child_process from 'node:child_process';
 

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -8,12 +8,12 @@ import chaiAsPromised from 'chai-as-promised';
 import mockfs from 'mock-fs';
 
 import { Headers } from 'node-fetch';
-import { HttpMethod } from '.';
+import { HttpMethod } from './index.js';
 import { assertRequestAgentsEqual, assertRequestOptionsEqual } from '../test/match-buffer';
-import { CoreV1Api, RequestContext } from './api';
-import { bufferFromFileOrString, findHomeDir, findObject, KubeConfig, makeAbsolutePath } from './config';
-import { ActionOnInvalid, Cluster, newClusters, newContexts, newUsers, User } from './config_types';
-import { ExecAuth } from './exec_auth';
+import { CoreV1Api, RequestContext } from './api.js';
+import { bufferFromFileOrString, findHomeDir, findObject, KubeConfig, makeAbsolutePath } from './config.js';
+import { ActionOnInvalid, Cluster, newClusters, newContexts, newUsers, User } from './config_types.js';
+import { ExecAuth } from './exec_auth.js';
 
 const kcFileName = 'testdata/kubeconfig.yaml';
 const kc2FileName = 'testdata/kubeconfig-2.yaml';

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs';
 import https from 'node:https';
 import { Agent, RequestOptions } from 'node:https';
-import path, { join } from 'node:path';
+import path, { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -25,6 +26,8 @@ const kcNoUserFileName = 'testdata/empty-user-kubeconfig.yaml';
 const kcInvalidContextFileName = 'testdata/empty-context-kubeconfig.yaml';
 const kcInvalidClusterFileName = 'testdata/empty-cluster-kubeconfig.yaml';
 const kcTlsServerNameFileName = 'testdata/tls-server-name-kubeconfig.yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 use(chaiAsPromised);
 

--- a/src/cp.ts
+++ b/src/cp.ts
@@ -3,8 +3,8 @@ import { WritableStreamBuffer } from 'stream-buffers';
 import * as tar from 'tar';
 import tmp from 'tmp-promise';
 
-import { KubeConfig } from './config';
-import { Exec } from './exec';
+import { KubeConfig } from './config.js';
+import { Exec } from './exec.js';
 
 export class Cp {
     public execInstance: Exec;

--- a/src/cp_test.ts
+++ b/src/cp_test.ts
@@ -3,10 +3,10 @@ import querystring from 'node:querystring';
 import WebSocket from 'isomorphic-ws';
 
 import { CallAwaiter } from '../test';
-import { KubeConfig } from './config';
-import { Exec } from './exec';
-import { Cp } from './cp';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { KubeConfig } from './config.js';
+import { Exec } from './exec.js';
+import { Cp } from './cp.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 describe('Cp', () => {
     describe('cpFromPod', () => {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -2,10 +2,10 @@ import WebSocket from 'isomorphic-ws';
 import querystring from 'node:querystring';
 import stream from 'stream';
 
-import { V1Status } from './api';
-import { KubeConfig } from './config';
-import { isResizable, ResizableStream, TerminalSizeQueue } from './terminal-size-queue';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { V1Status } from './api.js';
+import { KubeConfig } from './config.js';
+import { isResizable, ResizableStream, TerminalSizeQueue } from './terminal-size-queue.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 export class Exec {
     public 'handler': WebSocketInterface;

--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -1,8 +1,8 @@
 import { OutgoingHttpHeaders } from 'node:http';
 import https from 'node:https';
 
-import { Authenticator } from './auth';
-import { User } from './config_types';
+import { Authenticator } from './auth.js';
+import { User } from './config_types.js';
 
 import child_process from 'node:child_process';
 

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -5,8 +5,8 @@ use(chaiAsPromised);
 import https from 'node:https';
 import { OutgoingHttpHeaders } from 'node:http';
 
-import { ExecAuth } from './exec_auth';
-import { User } from './config_types';
+import { ExecAuth } from './exec_auth.js';
+import { User } from './config_types.js';
 
 import child_process from 'node:child_process';
 

--- a/src/exec_test.ts
+++ b/src/exec_test.ts
@@ -4,11 +4,11 @@ import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, anything, capture, instance, mock, verify, when } from 'ts-mockito';
 
 import { CallAwaiter, matchBuffer, ResizableWriteableStreamBuffer } from '../test';
-import { V1Status } from './api';
-import { KubeConfig } from './config';
-import { Exec } from './exec';
-import { TerminalSize } from './terminal-size-queue';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { V1Status } from './api.js';
+import { KubeConfig } from './config.js';
+import { Exec } from './exec.js';
+import { TerminalSize } from './terminal-size-queue.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 describe('Exec', () => {
     describe('basic', () => {

--- a/src/file_auth.ts
+++ b/src/file_auth.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import https from 'node:https';
 
-import { Authenticator } from './auth';
-import { User } from './config_types';
+import { Authenticator } from './auth.js';
+import { User } from './config_types.js';
 
 export class FileAuth implements Authenticator {
     private token: string | null = null;

--- a/src/file_auth_test.ts
+++ b/src/file_auth_test.ts
@@ -3,8 +3,8 @@ import { OutgoingHttpHeaders } from 'node:http';
 import https from 'node:https';
 import mockfs from 'mock-fs';
 
-import { User } from './config_types';
-import { FileAuth } from './file_auth';
+import { User } from './config_types.js';
+import { FileAuth } from './file_auth.js';
 
 describe('FileAuth', () => {
     it('should refresh when null', async () => {

--- a/src/gcp_auth.ts
+++ b/src/gcp_auth.ts
@@ -1,9 +1,9 @@
 import proc from 'node:child_process';
 import https from 'node:https';
-import jsonpath from 'jsonpath-plus';
+import * as jsonpath from 'jsonpath-plus';
 
-import { Authenticator } from './auth';
-import { User } from './config_types';
+import { Authenticator } from './auth.js';
+import { User } from './config_types.js';
 
 /* FIXME: maybe we can extend the User and User.authProvider type to have a proper type.
 Currently user.authProvider has `any` type and so we don't have a type for user.authProvider.config.

--- a/src/gcp_auth_test.ts
+++ b/src/gcp_auth_test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { join } from 'node:path';
 
-import { User, Cluster } from './config_types';
-import { GoogleCloudPlatformAuth } from './gcp_auth';
-import { KubeConfig } from './config';
-import { HttpMethod, RequestContext } from './gen';
+import { User, Cluster } from './config_types.js';
+import { GoogleCloudPlatformAuth } from './gcp_auth.js';
+import { KubeConfig } from './config.js';
+import { HttpMethod, RequestContext } from './gen/index.js';
 import { Agent } from 'node:https';
 
 describe('GoogleCloudPlatformAuth', () => {

--- a/src/gcp_auth_test.ts
+++ b/src/gcp_auth_test.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { User, Cluster } from './config_types.js';
 import { GoogleCloudPlatformAuth } from './gcp_auth.js';
 import { KubeConfig } from './config.js';
 import { HttpMethod, RequestContext } from './gen/index.js';
 import { Agent } from 'node:https';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('GoogleCloudPlatformAuth', () => {
     const testUrl1 = 'https://test-gcp.com';

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,5 +1,5 @@
-import fetch, { AbortError } from 'node-fetch';
-import { KubeConfig } from './config';
+import fetch from 'node-fetch';
+import { KubeConfig } from './config.js';
 import { RequestOptions } from 'node:https';
 
 export class Health {

--- a/src/health_test.ts
+++ b/src/health_test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import nock from 'nock';
 
-import { KubeConfig } from './config';
-import { Health } from './health';
-import { Cluster, User } from './config_types';
+import { KubeConfig } from './config.js';
+import { Health } from './health.js';
+import { Cluster, User } from './config_types.js';
 
 describe('Health', () => {
     describe('livez', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export * from './patch.js';
 export * from './metrics.js';
 export * from './object.js';
 export * from './health.js';
-export { ConfigOptions, User, Cluster, Context } from './config_types.js';
+export { type ConfigOptions, type User, type Cluster, type Context } from './config_types.js';
 
 // Export FetchError so that instanceof checks in user code will definitely use the same instance
 export { FetchError } from 'node-fetch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
-export * from './config';
-export * from './cache';
-export * from './api';
-export * from './attach';
-export * from './watch';
-export * from './exec';
-export * from './portforward';
-export * from './types';
-export * from './yaml';
-export * from './log';
-export * from './informer';
-export * from './top';
-export * from './cp';
-export * from './patch';
-export * from './metrics';
-export * from './object';
-export * from './health';
-export { ConfigOptions, User, Cluster, Context } from './config_types';
+export * from './config.js';
+export * from './cache.js';
+export * from './api.js';
+export * from './attach.js';
+export * from './watch.js';
+export * from './exec.js';
+export * from './portforward.js';
+export * from './types.js';
+export * from './yaml.js';
+export * from './log.js';
+export * from './informer.js';
+export * from './top.js';
+export * from './cp.js';
+export * from './patch.js';
+export * from './metrics.js';
+export * from './object.js';
+export * from './health.js';
+export { ConfigOptions, User, Cluster, Context } from './config_types.js';
 
-// Export AbortError and FetchError so that instanceof checks in user code will definitely use the same instances
-export { AbortError, FetchError } from 'node-fetch';
+// Export FetchError so that instanceof checks in user code will definitely use the same instance
+export { FetchError } from 'node-fetch';

--- a/src/informer.ts
+++ b/src/informer.ts
@@ -1,7 +1,7 @@
-import { ListWatch } from './cache';
-import { KubeConfig } from './config';
-import { KubernetesListObject, KubernetesObject } from './types';
-import { Watch } from './watch';
+import { ListWatch } from './cache.js';
+import { KubeConfig } from './config.js';
+import { KubernetesListObject, KubernetesObject } from './types.js';
+import { Watch } from './watch.js';
 
 export type ObjectCallback<T extends KubernetesObject> = (obj: T) => void;
 export type ErrorCallback = (err?: any) => void;

--- a/src/integration_test.ts
+++ b/src/integration_test.ts
@@ -2,9 +2,9 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
 
-import { CoreV1Api } from './api';
-import { KubeConfig } from './config';
-import { Cluster, User } from './config_types';
+import { CoreV1Api } from './api.js';
+import { KubeConfig } from './config.js';
+import { Cluster, User } from './config_types.js';
 
 use(chaiAsPromised);
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,9 +1,9 @@
 import fetch from 'node-fetch';
 import { Writable } from 'node:stream';
-import { ApiException } from './api';
-import { KubeConfig } from './config';
-import { V1Status } from './gen';
-import { normalizeResponseHeaders } from './util';
+import { ApiException } from './api.js';
+import { KubeConfig } from './config.js';
+import { V1Status } from './gen/index.js';
+import { normalizeResponseHeaders } from './util.js';
 
 export interface LogOptions {
     /**

--- a/src/log_test.ts
+++ b/src/log_test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { AddOptionsToSearchParams, LogOptions } from './log';
+import { AddOptionsToSearchParams, LogOptions } from './log.js';
 
 describe('Log', () => {
     describe('AddOptionsToSearchParams', () => {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
-import { KubeConfig } from './config';
-import { ApiException, V1Status } from './gen';
-import { normalizeResponseHeaders } from './util';
+import { KubeConfig } from './config.js';
+import { ApiException, V1Status } from './gen/index.js';
+import { normalizeResponseHeaders } from './util.js';
 
 export interface Usage {
     cpu: string;

--- a/src/metrics_test.ts
+++ b/src/metrics_test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import nock from 'nock';
-import { KubeConfig } from './config';
-import { V1Status, ApiException } from './gen';
-import { Metrics, NodeMetricsList, PodMetricsList } from './metrics';
+import { KubeConfig } from './config.js';
+import { V1Status, ApiException } from './gen/index.js';
+import { Metrics, NodeMetricsList, PodMetricsList } from './metrics.js';
 
 const emptyPodMetrics: PodMetricsList = {
     kind: 'PodMetricsList',

--- a/src/object.ts
+++ b/src/object.ts
@@ -9,12 +9,12 @@ import {
     V1APIResourceList,
     V1DeleteOptions,
     V1Status,
-} from './api';
-import { KubeConfig } from './config';
-import { ObjectSerializer } from './serializer';
-import { KubernetesListObject, KubernetesObject } from './types';
-import { from, mergeMap, of } from './gen/rxjsStub';
-import { PatchStrategy } from './patch';
+} from './api.js';
+import { KubeConfig } from './config.js';
+import { ObjectSerializer } from './serializer.js';
+import { KubernetesListObject, KubernetesObject } from './types.js';
+import { from, mergeMap, of } from './gen/rxjsStub.js';
+import { PatchStrategy } from './patch.js';
 
 /** Kubernetes API verbs. */
 type KubernetesApiAction = 'create' | 'delete' | 'patch' | 'read' | 'list' | 'replace';

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import nock from 'nock';
-import { Configuration, V1APIResource, V1APIResourceList, V1Secret } from './api';
-import { KubeConfig } from './config';
-import { KubernetesObjectApi } from './object';
-import { KubernetesObject } from './types';
-import { of } from './gen/rxjsStub';
+import { Configuration, V1APIResource, V1APIResourceList, V1Secret } from './api.js';
+import { KubeConfig } from './config.js';
+import { KubernetesObjectApi } from './object.js';
+import { KubernetesObject } from './types.js';
+import { of } from './gen/rxjsStub.js';
 
 describe('KubernetesObject', () => {
     const testConfigOptions = {

--- a/src/oidc_auth.ts
+++ b/src/oidc_auth.ts
@@ -2,8 +2,8 @@ import https from 'node:https';
 import * as oidc from 'openid-client';
 import { base64url } from 'rfc4648';
 
-import { Authenticator } from './auth';
-import { User } from './config_types';
+import { Authenticator } from './auth.js';
+import { User } from './config_types.js';
 
 interface JwtObj {
     header: any;

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -3,8 +3,8 @@ import { OutgoingHttpHeaders } from 'node:http';
 import https from 'node:https';
 import { base64url } from 'rfc4648';
 
-import { User } from './config_types';
-import { OpenIDConnectAuth } from './oidc_auth';
+import { User } from './config_types.js';
+import { OpenIDConnectAuth } from './oidc_auth.js';
 
 function encode(value: string): string {
     return base64url.stringify(new TextEncoder().encode(value));

--- a/src/package_test.ts
+++ b/src/package_test.ts
@@ -1,4 +1,6 @@
+import { createRequire } from 'node:module';
 import { expect } from 'chai';
+const require = createRequire(import.meta.url);
 
 // Generic set of tests to verify the package is built and configured correctly
 describe('package', () => {

--- a/src/portforward.ts
+++ b/src/portforward.ts
@@ -2,8 +2,8 @@ import WebSocket from 'isomorphic-ws';
 import querystring from 'node:querystring';
 import stream from 'node:stream';
 
-import { KubeConfig } from './config';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { KubeConfig } from './config.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 export class PortForward {
     private readonly handler: WebSocketInterface;

--- a/src/portforward_test.ts
+++ b/src/portforward_test.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, capture, instance, mock, verify } from 'ts-mockito';
 
-import { KubeConfig } from './config';
-import { PortForward } from './portforward';
-import { WebSocketHandler, WebSocketInterface } from './web-socket-handler';
+import { KubeConfig } from './config.js';
+import { PortForward } from './portforward.js';
+import { WebSocketHandler, WebSocketInterface } from './web-socket-handler.js';
 
 describe('PortForward', () => {
     it('should correctly port-forward to a url', async () => {

--- a/src/proto-client.ts
+++ b/src/proto-client.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 
-import { KubeConfig } from './config';
+import { KubeConfig } from './config.js';
 
 export class ProtoClient {
     public readonly 'config': KubeConfig;

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,4 +1,4 @@
-import { ObjectSerializer as InternalSerializer, V1ObjectMeta } from './gen/models/ObjectSerializer';
+import { ObjectSerializer as InternalSerializer, V1ObjectMeta } from './gen/models/ObjectSerializer.js';
 
 type AttributeType = {
     name: string;

--- a/src/serializer_test.ts
+++ b/src/serializer_test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ObjectSerializer } from './serializer';
+import { ObjectSerializer } from './serializer.js';
 
 describe('ObjectSerializer', () => {
     describe('serialize', () => {

--- a/src/top.ts
+++ b/src/top.ts
@@ -1,5 +1,5 @@
-import { CoreV1Api, V1Node, V1Pod, V1PodList } from './gen';
-import { Metrics, PodMetric } from './metrics';
+import { CoreV1Api, V1Node, V1Pod, V1PodList } from './gen/index.js';
+import { Metrics, PodMetric } from './metrics.js';
 import {
     add,
     podsForNode,
@@ -8,7 +8,7 @@ import {
     totalCPUForContainer,
     totalMemory,
     totalMemoryForContainer,
-} from './util';
+} from './util.js';
 
 export class ResourceUsage {
     constructor(

--- a/src/top_test.ts
+++ b/src/top_test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import nock from 'nock';
-import { KubeConfig } from './config';
-import { Metrics, PodMetricsList } from './metrics';
-import { topPods } from './top';
-import { CoreV1Api, V1Pod } from './api';
+import { KubeConfig } from './config.js';
+import { Metrics, PodMetricsList } from './metrics.js';
+import { topPods } from './top.js';
+import { CoreV1Api, V1Pod } from './api.js';
 
 const emptyPodMetrics: PodMetricsList = {
     kind: 'PodMetricsList',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { V1ListMeta, V1ObjectMeta } from './api';
+import { V1ListMeta, V1ObjectMeta } from './api.js';
 
 export interface KubernetesObject {
     apiVersion?: string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { Response } from 'node-fetch';
-import { CoreV1Api, V1Container, V1Pod } from './gen';
+import { CoreV1Api, V1Container, V1Pod } from './gen/index.js';
 
 export async function podsForNode(api: CoreV1Api, nodeName: string): Promise<V1Pod[]> {
     const allPods = await api.listPodForAllNamespaces();

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -1,6 +1,6 @@
 import { expect, assert } from 'chai';
 import { Response } from 'node-fetch';
-import { CoreV1Api, V1Container, V1Pod } from './api';
+import { CoreV1Api, V1Container, V1Pod } from './api.js';
 import {
     normalizeResponseHeaders,
     findSuffix,
@@ -8,7 +8,7 @@ import {
     quantityToScalar,
     totalCPU,
     totalMemory,
-} from './util';
+} from './util.js';
 
 describe('Utils', () => {
     it('should get zero pods for a node', async () => {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,6 +1,6 @@
 import { createInterface } from 'node:readline';
 import fetch from 'node-fetch';
-import { KubeConfig } from './config';
+import { KubeConfig } from './config.js';
 
 export class Watch {
     public static SERVER_SIDE_CLOSE: object = { error: 'Connection closed on server' };

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import nock from 'nock';
 import { PassThrough } from 'node:stream';
-import { KubeConfig } from './config';
-import { Cluster, Context, User } from './config_types';
-import { Watch } from './watch';
+import { KubeConfig } from './config.js';
+import { Cluster, Context, User } from './config_types.js';
+import { Watch } from './watch.js';
 import { IncomingMessage } from 'node:http';
 
 const server = 'http://foo.company.com';

--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -1,8 +1,8 @@
 import WebSocket from 'isomorphic-ws';
 import stream from 'node:stream';
 
-import { V1Status } from './api';
-import { KubeConfig } from './config';
+import { V1Status } from './api.js';
+import { KubeConfig } from './config.js';
 
 const protocols = [
     'v5.channel.k8s.io',

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -4,10 +4,10 @@ import { expect } from 'chai';
 import WebSocket from 'isomorphic-ws';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 
-import { V1Status } from './api';
-import { KubeConfig } from './config';
-import { Cluster, Context, User } from './config_types';
-import { WebSocketHandler } from './web-socket-handler';
+import { V1Status } from './api.js';
+import { KubeConfig } from './config.js';
+import { Cluster, Context, User } from './config_types.js';
+import { WebSocketHandler } from './web-socket-handler.js';
 
 describe('WebSocket', () => {
     it('should throw on unknown code', () => {

--- a/src/yaml_test.ts
+++ b/src/yaml_test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { V1Namespace } from './api';
-import { dumpYaml, loadAllYaml, loadYaml } from './yaml';
+import { V1Namespace } from './api.js';
+import { dumpYaml, loadAllYaml, loadYaml } from './yaml.js';
 
 describe('yaml', () => {
     it('should load safely', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "nodenext",
         "noImplicitAny": false,
         "target": "es2019",
-        "lib": ["es2021"],
-        "moduleResolution": "node",
+        "lib": ["es2023"],
+        "moduleResolution": "nodenext",
         "removeComments": false,
         "sourceMap": true,
         "noLib": false,

--- a/version-check.js
+++ b/version-check.js
@@ -1,9 +1,13 @@
 // This script is supposed to be run in travis to check package version matches
-// because of this it is designed to be run on a "clean" git checkout 
+// because of this it is designed to be run on a "clean" git checkout
 // this will fail if run after npm install (since npm install updates package-lock)
-const packageVersion = require('./package.json').version 
-const lockVersion = require('./package-lock.json').version
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const packageVersion = require('./package.json').version;
+const lockVersion = require('./package-lock.json').version;
 if (packageVersion != lockVersion) {
-    console.log(`version in package.json (${packageVersion}) does not match package-lock.json (${lockVersion})`);
+    console.log(
+        `version in package.json (${packageVersion}) does not match package-lock.json (${lockVersion})`,
+    );
     process.exit(1);
 }


### PR DESCRIPTION
This is a substantial change that moves the release-1.x branch from CommonJS to ESM as discussed in
https://github.com/kubernetes-client/javascript/issues/2014. Please review/test carefully.

This commit does the following things:

- Updates the tsconfig to generate ESM code. The formatter also automatically formatted this file.
- Add `"type": "module"` to the `package.json` so that consumers treat this as ESM instead of CJS.
- Updates all of the imports to be valid ESM imports. ESM requires that file extensions are provided. TypeScript is smart enough to handle the `.js` extensions, but TypeScript does not support adding the extensions at build time. See https://github.com/microsoft/TypeScript/issues/16577 for more details about this. The `tsc-esm-fix` utility on npm was used to automatically add the extensions. The code generator probably needs to add support for this too if it doesn't already.
- Fixup the `jsonpath` imports, as this module does not have a default ESM export. This just means adding `* as` to the existing imports.
- Remove the `AbortError` export originating from `node-fetch`. Apparently this is not actually there.

I was able to successfully import the transpiled code using `import * as k8s from './dist/index.js';`. This should hopefully unblock running tests against the transpiled code as well (it currently does not work because the openid-client and chai dependencies have both moved to ESM only).