### PR TITLE
web-socket-handler: fix type for TypeScript update

### DIFF
--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -262,7 +262,7 @@ function copyChunkForWebSocket(
         encoding ??= 'utf-8';
         const size = Buffer.byteLength(chunk, encoding);
         buff = Buffer.alloc(size + 1);
-        buff.write(chunk, 1, size, encoding);
+        buff.write(chunk as string, 1, size, encoding);
     }
 
     buff.writeInt8(streamNum, 0);


### PR DESCRIPTION
The TypeScript 5.7.2 update does not like one of the types. I'm not sure why TypeScript can't figure it out, but this commit updates the bad type. #2050 should be unblocked after this.

Refs: https://github.com/kubernetes-client/javascript/pull/2050