### PR TITLE
Do not close whole websocket when v5 protocol is supported

### DIFF
--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -106,8 +106,9 @@ export class WebSocketHandler implements WebSocketInterface {
                 buff.writeUint8(this.CloseStream, 0);
                 buff.writeUint8(this.StdinStream, 1);
                 ws.send(buff);
+            } else {
+                ws.close();
             }
-            ws.close();
         });
         // Keep the stream open
         return true;

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -389,12 +389,15 @@ describe('V5 protocol support', () => {
     });
     it('should handle closing stdin v5 protocol', () => {
         let sent: Buffer | null = null;
+        let closed = false
         const ws = {
             protocol: 'v5.channel.k8s.io',
             send: (data) => {
                 sent = data;
             },
-            close: () => {},
+            close: () => {
+                closed = true
+            },
         } as WebSocket;
         const stdinStream = new ReadableStreamBuffer();
         WebSocketHandler.handleStandardInput(ws, stdinStream);
@@ -402,6 +405,7 @@ describe('V5 protocol support', () => {
         expect(sent).to.not.be.null;
         expect(sent!.readUint8(0)).to.equal(255); // CLOSE signal
         expect(sent!.readUint8(1)).to.equal(0); // Stdin stream is #0
+        expect(closed).to.equal(false)
     });
 });
 


### PR DESCRIPTION
Recently the v5.channel.k8s.io was implemented allowing to close exec streams.

But the close still closes the whole websocket when the stdin is closed