### PR TITLE
deps: remove colors override

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
         "arrowParens": "always"
     },
     "overrides": {
-        "colors": "1.4.0",
         "whatwg-url@<12.0.1": "12.0.1"
     }
 }


### PR DESCRIPTION
It appears that the `colors` package does not exist anywhere in the dependency tree anymore. This commit removes the override. [Overrides also do not appear to be applied for end users anyway](https://github.com/kubernetes-client/javascript/pull/1953#issuecomment-2551660086).