### PR TITLE
ci: set workflow permissions for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+    contents: write
+
 on:
     workflow_dispatch:
         inputs:


### PR DESCRIPTION
We had the issue that the github action wasnt able to push tags to github. This should fix the issue

ref: #1828
