### PR TITLE
chore: add cjihrig to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,10 +3,12 @@ approvers:
 - brendandburns
 - mstruebing
 - davidgamero
+- cjihrig
 reviewers:
 - brendandburns
 - mstruebing
 - davidgamero
+- cjihrig
 emeritus_approvers:
 - mbohlool # 10/22/2020
 - drubin # 11/23/2023


### PR DESCRIPTION
I previously added myself to OWNERS on the master branch. It appears that I need to be added on the release-1.x branch as well in order to merge PRs from non-maintainers (see https://github.com/kubernetes-client/javascript/pull/2111#issuecomment-2557450966).