### PR TITLE
Fix type definition for KubernetesObjectApi.read()

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -19,6 +19,16 @@ import { PatchStrategy } from './patch.js';
 /** Kubernetes API verbs. */
 type KubernetesApiAction = 'create' | 'delete' | 'patch' | 'read' | 'list' | 'replace';
 
+type KubernetesObjectHeader<T extends KubernetesObject | KubernetesObject> = Pick<
+    T,
+    'apiVersion' | 'kind'
+> & {
+    metadata: {
+        name: string;
+        namespace?: string;
+    };
+};
+
 interface GroupVersion {
     group: string;
     version: string;
@@ -278,7 +288,7 @@ export class KubernetesObjectApi {
      * @return Promise containing the request response and [[KubernetesObject]].
      */
     public async read<T extends KubernetesObject | KubernetesObject>(
-        spec: T,
+        spec: KubernetesObjectHeader<T>,
         pretty?: string,
         exact?: boolean,
         exportt?: boolean,

--- a/src/object.ts
+++ b/src/object.ts
@@ -19,16 +19,6 @@ import { PatchStrategy } from './patch.js';
 /** Kubernetes API verbs. */
 type KubernetesApiAction = 'create' | 'delete' | 'patch' | 'read' | 'list' | 'replace';
 
-type KubernetesObjectHeader<T extends KubernetesObject | KubernetesObject> = Pick<
-    T,
-    'apiVersion' | 'kind'
-> & {
-    metadata: {
-        name: string;
-        namespace?: string;
-    };
-};
-
 interface GroupVersion {
     group: string;
     version: string;
@@ -288,7 +278,7 @@ export class KubernetesObjectApi {
      * @return Promise containing the request response and [[KubernetesObject]].
      */
     public async read<T extends KubernetesObject | KubernetesObject>(
-        spec: KubernetesObjectHeader<T>,
+        spec: T,
         pretty?: string,
         exact?: boolean,
         exportt?: boolean,

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1725,7 +1725,7 @@ describe('KubernetesObject', () => {
 
         it('should read a custom resource', async () => {
             interface CustomTestResource extends KubernetesObject {
-                spec?: {
+                spec: {
                     key: string;
                 };
             }


### PR DESCRIPTION
Resolves https://github.com/kubernetes-client/javascript/issues/2128

This PR restores the old type definition that existed in 0.x.