### PR TITLE
examples: fix kubectl examples for v1

### DIFF
--- a/examples/kubectl/equivalents/apply.js
+++ b/examples/kubectl/equivalents/apply.js
@@ -7,15 +7,15 @@ const client = k8s.KubernetesObjectApi.makeApiClient(kc);
 
 // update deployment "my-deployment" in namespace "my-namespace" to 3 replicas
 const deployment = {
-  apiVersion: 'apps/v1',
-  kind: 'Deployment',
-  metadata: {
-    name: 'my-deployment',
-    namespace: 'my-namespace'
-  },
-  spec: {
-    replicas: 3
-  }
-}
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+        name: 'my-deployment',
+        namespace: 'my-namespace',
+    },
+    spec: {
+        replicas: 3,
+    },
+};
 
-client.patch(deployment)
+client.patch(deployment);

--- a/examples/kubectl/equivalents/create.js
+++ b/examples/kubectl/equivalents/create.js
@@ -4,11 +4,11 @@ const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const client = k8s.KubernetesObjectApi.makeApiClient(kc);
-
 const namespace = {
+    kind: 'Namespace',
     metadata: {
-        name: 'test'
-    }
-}
+        name: 'test',
+    },
+};
 
-client.create(namespace)
+client.create(namespace);

--- a/examples/kubectl/equivalents/delete.js
+++ b/examples/kubectl/equivalents/delete.js
@@ -4,11 +4,11 @@ const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const client = k8s.KubernetesObjectApi.makeApiClient(kc);
-
 const namespace = {
+    kind: 'Namespace',
     metadata: {
-        name: 'test'
-    }
-}
+        name: 'test',
+    },
+};
 
-client.delete(namespace)
+client.delete(namespace);

--- a/examples/kubectl/equivalents/get.js
+++ b/examples/kubectl/equivalents/get.js
@@ -4,12 +4,12 @@ const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const client = k8s.KubernetesObjectApi.makeApiClient(kc);
-
 const namespace = {
+    apiVersion: 'v1',
+    kind: 'Namespace',
     metadata: {
-        name: 'test'
-    }
-}
+        name: 'test',
+    },
+};
 
-const live_namespace = (await client.read(namespace)).body
-console.log(live_namespace)
+console.log(await client.read(namespace));


### PR DESCRIPTION
This commit updates the kubectl examples to work with the v1 branch.