### PR TITLE
Reintroduce timeout and keep-alive for watch requests to match client-go

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -40,6 +40,7 @@ export class Watch {
         const controller = new AbortController();
         requestInit.signal = controller.signal as AbortSignal;
         requestInit.method = 'GET';
+        requestInit.timeout = 30000;
 
         let doneCalled: boolean = false;
         const doneCallOnce = (err: any) => {
@@ -52,6 +53,15 @@ export class Watch {
 
         try {
             const response = await fetch(watchURL, requestInit);
+
+            // Enable socket keep-alive to prevent connection stalls
+            if (requestInit.agent && typeof requestInit.agent === 'object') {
+                for (const socket of Object.values(requestInit.agent.sockets).flat()) {
+                    if (socket) {
+                        socket.setKeepAlive(true, 30000);
+                    }
+                }
+            }
 
             if (response.status === 200) {
                 response.body.on('error', doneCallOnce);


### PR DESCRIPTION
This will send sends keep-alive probes to the server every 30 seconds. These features were present prior to the 1.0 but were inadvertently removed.

Fixes #2127

Previous relevant issues:
- Initial issue: #559
  - PR: #630
- Improvement: #632
  - PR: #635

### Implementation details
Setting `requestInit.timeout = 30000` is equivalent to `socket.setTimeout(30000)` as you can [see in the sources](https://github.com/nodejs/node/blob/main/lib/_http_agent.js#L527).

One of the solution suggested in #2127 was to use the keepAlive of the `http.Agent`. But [as documented here](https://nodejs.org/api/http.html#new-agentoptions), that's just a boolean that instruct the agent that we want sockets to be re-used. We want to send packets at a fixed rate to know when a connection is broken. This can be done with the [`socket.setKeepAlive()` method](https://nodejs.org/api/net.html#socketsetkeepaliveenable-initialdelay), but to use it, we need to access the socket object.

I managed to access the socket and call `setKeepAlive()`, but only after the `await fetch()`, when the response is already arriving. That's the only way I found to access the socket. The Agent create the socket, but [there is no event](https://nodejs.org/api/http.html#class-httpagent) to know when a socket created, you can just access them by list like I did. There is a[ `socket` event on the request object](https://nodejs.org/api/http.html#event-socket), but `node-fetch` abstract it away, and I couldn't find a clean way to access it ([See discussion](https://github.com/node-fetch/node-fetch/discussions/1720) that request this feature).

The only way I've found to get the socket before the request was by monkey-patching the `agent.createConnection()`, but I think this solution is worse.
```javascript
const _createConnection = agent.createConnection;
agent.createConnection = function (...args) {
  const socket = _createConnection.apply(agent, args);
  socket.setTimeout(3000);
  socket.setKeepAlive(true, 3000);
  return socket;
}
```