### PR TITLE
chore: fix markdown in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ Code snippet for what you are doing
 **Environment (please complete the following information):**
 
 - OS: [e.g. Windows, Linux]
-- NodeJS Version [eg. 10]
+- Node.js version [eg. 20]
 - Cloud runtime [e.g. Azure Functions, Lambda]
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,16 +4,15 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-** Client Version **
+**Client Version**
 e.g. `0.12.0`
 
-** Server Version **
+**Server Version**
 e.g. `1.19.1`
 
 **To Reproduce**
@@ -22,13 +21,14 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-** Example Code**
+**Example Code**
 Code snippet for what you are doing
 
 **Environment (please complete the following information):**
- - OS: [e.g. Windows, Linux]
- - NodeJS Version [eg. 10]
- - Cloud runtime [e.g. Azure Functions, Lambda]
+
+- OS: [e.g. Windows, Linux]
+- NodeJS Version [eg. 10]
+- Cloud runtime [e.g. Azure Functions, Lambda]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
This commit removes extra whitespace that prevents the issue template from rendering properly.