### PR TITLE
chore: update remaining release-1.x branch references

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,38 +10,38 @@
 # supported CodeQL languages.
 # ******** NOTE ********
 
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
-  push:
-    branches: [ master,release-1.x ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master,release-1.x ]
-  schedule:
-    - cron: '35 14 * * 3'
+    push:
+        branches: [master, main]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [master, main]
+    schedule:
+        - cron: '35 14 * * 3'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ['javascript']
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v2
+              with:
+                  languages: ${{ matrix.language }}
+
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v2
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v2

--- a/pre-check.sh
+++ b/pre-check.sh
@@ -2,8 +2,8 @@
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ "${branch}" != "release-1.x" ]]; then
-  echo "This script can only be run on the release-1.x branch. Current branch is ${branch}"
+if [[ "${branch}" != "main" ]]; then
+  echo "This script can only be run on the main branch. Current branch is ${branch}"
   exit 1
 fi
 


### PR DESCRIPTION
The release-1.x branch was renamed to main. This commit cleans up the remaining references to release-1.x.