### PR TITLE
examples: fix typescript examples for v1

### DIFF
--- a/examples/typescript/apply/apply-example.ts
+++ b/examples/typescript/apply/apply-example.ts
@@ -7,15 +7,15 @@ const client = k8s.KubernetesObjectApi.makeApiClient(kc);
 
 // update deployment "my-deployment" in namespace "my-namespace" to 3 replicas
 const deployment = {
-  apiVersion: 'apps/v1',
-  kind: 'Deployment',
-  metadata: {
-    name: 'my-deployment',
-    namespace: 'my-namespace'
-  },
-  spec: {
-    replicas: 3
-  }
-}
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+        name: 'my-deployment',
+        namespace: 'my-namespace',
+    },
+    spec: {
+        replicas: 3,
+    },
+};
 
-client.patch(deployment)
+client.patch(deployment);

--- a/examples/typescript/apply/apply-from-file-example.ts
+++ b/examples/typescript/apply/apply-from-file-example.ts
@@ -36,14 +36,14 @@ export async function apply(specPath: string): Promise<k8s.KubernetesObject[]> {
             //
             // See: https://github.com/kubernetes/kubernetes/issues/97423
             const response = await client.patch(spec);
-            created.push(response.body);
+            created.push(response);
         } catch (err) {
             // if the resource doesnt exist then create it
-            if (err instanceof k8s.HttpError && err.statusCode === 404) {
-              const response = await client.create(spec);
-              created.push(response.body);
+            if (err instanceof k8s.ApiException && err.code === 404) {
+                const response = await client.create(spec);
+                created.push(response);
             } else {
-              throw err
+                throw err;
             }
         }
     }

--- a/examples/typescript/attach/attach-example.ts
+++ b/examples/typescript/attach/attach-example.ts
@@ -9,4 +9,12 @@ const namespace = 'default';
 const pod = 'nginx-4217019353-9gl4s';
 const container = 'nginx';
 
-attach.attach(namespace, pod, container, process.stdout, process.stderr, null /* stdin */, false /* tty */);
+await attach.attach(
+    namespace,
+    pod,
+    container,
+    process.stdout,
+    process.stderr,
+    null /* stdin */,
+    false /* tty */,
+);

--- a/examples/typescript/cp/cp-example.ts
+++ b/examples/typescript/cp/cp-example.ts
@@ -8,7 +8,7 @@ const cp = new k8s.Cp(kc);
 const namespace = 'default';
 const pod = 'nginx-4217019353-9gl4s';
 const container = 'nginx';
-const srcPath = '/test.txt';
+const srcPath = './test.txt';
 const targetPath = '/tmp';
 
-cp.cpFromPod(namespace, pod, container, srcPath, targetPath);
+await cp.cpFromPod(namespace, pod, container, srcPath, targetPath);

--- a/examples/typescript/informer/informer.ts
+++ b/examples/typescript/informer/informer.ts
@@ -1,15 +1,11 @@
 import * as k8s from '@kubernetes/client-node';
 
 const kc = new k8s.KubeConfig();
-
 kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
-
 const namespace = 'default';
-
 const listFn = () => k8sApi.listNamespacedPod({ namespace });
-
 const informer = k8s.makeInformer(kc, `/api/v1/namespaces/${namespace}/pods`, listFn);
 
 informer.on('add', (obj: k8s.V1Pod) => {

--- a/examples/typescript/patch/patch-example.ts
+++ b/examples/typescript/patch/patch-example.ts
@@ -4,7 +4,7 @@ import {
     ResponseContext,
     KubeConfig,
     createConfiguration,
-    Configuration,
+    type Configuration,
     ServerConfiguration,
 } from '@kubernetes/client-node';
 import { PromiseMiddlewareWrapper } from '@kubernetes/client-node/dist/gen/middleware.js';
@@ -50,7 +50,7 @@ try {
             default: kc,
         },
     });
-    const podName = res.items[0].metadata?.name;
+    const podName = res.items[0]?.metadata?.name;
     if (podName === undefined) {
         throw new Error('Pod name is undefined');
     }
@@ -62,7 +62,7 @@ try {
             body: patch,
         },
         configuration,
-    )
+    );
 
     console.log('Patched.');
 } catch (err) {

--- a/examples/typescript/simple/example.ts
+++ b/examples/typescript/simple/example.ts
@@ -8,7 +8,7 @@ const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 const namespace = 'default';
 
 const res = await k8sApi.listNamespacedPod({ namespace });
-console.log(res.body);
+console.log(res);
 
 // Example of instantiating a Pod object.
 const pod = {} as k8s.V1Pod;


### PR DESCRIPTION
This commit updates the typescript examples to work with the v1 branch. The examples were tested using Node 23 and the `--experimental-strip-types` flag.