### PR TITLE
examples: port missing examples from master to main

### DIFF
--- a/examples/kubectl/equivalents/namespace-create-yaml.js
+++ b/examples/kubectl/equivalents/namespace-create-yaml.js
@@ -1,0 +1,17 @@
+import * as k8s from '@kubernetes/client-node';
+import { readFileSync } from 'node:fs';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl apply -f namespace.yaml`.
+
+try {
+    const namespaceYaml = k8s.loadYaml(readFileSync('./namespace.yaml', 'utf8'));
+    const createdNamespace = await k8sApi.createNamespace({ body: namespaceYaml });
+    console.log('New namespace created:', createdNamespace);
+} catch (err) {
+    console.error(err);
+}

--- a/examples/kubectl/equivalents/namespace-create.js
+++ b/examples/kubectl/equivalents/namespace-create.js
@@ -1,0 +1,20 @@
+import * as k8s from '@kubernetes/client-node';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl create namespace test`.
+
+try {
+    const namespace = {
+        metadata: {
+            name: 'test',
+        },
+    };
+    const createdNamespace = await k8sApi.createNamespace({ body: namespace });
+    console.log('New namespace created:', createdNamespace);
+} catch (err) {
+    console.error(err);
+}

--- a/examples/kubectl/equivalents/namespace-list.js
+++ b/examples/kubectl/equivalents/namespace-list.js
@@ -1,0 +1,15 @@
+import * as k8s from '@kubernetes/client-node';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl get ns`.
+
+try {
+    const namespaces = await k8sApi.listNamespace();
+    namespaces.items.forEach((namespace) => console.log(namespace.metadata.name));
+} catch (err) {
+    console.error(err);
+}

--- a/examples/kubectl/equivalents/namespace.yaml
+++ b/examples/kubectl/equivalents/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: test

--- a/examples/kubectl/equivalents/pod-create.js
+++ b/examples/kubectl/equivalents/pod-create.js
@@ -1,0 +1,33 @@
+import * as k8s from '@kubernetes/client-node';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl run demo-pod --image=nginx --namespace=default`.
+
+const pod = {
+    metadata: {
+        name: 'demo-pod',
+    },
+    spec: {
+        containers: [
+            {
+                name: 'nginx-container',
+                image: 'nginx',
+            },
+        ],
+    },
+};
+const namespace = 'default';
+
+try {
+    const createdPod = await k8sApi.createNamespacedPod({
+        namespace,
+        body: pod,
+    });
+    console.log('Created pod:', createdPod);
+} catch (err) {
+    console.error(err);
+}

--- a/examples/kubectl/equivalents/pod-filter-by-namespace.js
+++ b/examples/kubectl/equivalents/pod-filter-by-namespace.js
@@ -1,0 +1,16 @@
+import * as k8s from '@kubernetes/client-node';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl get pods --namespace=default`.
+
+try {
+    const pods = await k8sApi.listNamespacedPod({ namespace: 'default' });
+
+    pods.items.forEach((pod) => console.log(pod.metadata.name));
+} catch (err) {
+    console.error(err);
+}

--- a/examples/kubectl/equivalents/resourceQuota-create.js
+++ b/examples/kubectl/equivalents/resourceQuota-create.js
@@ -1,0 +1,29 @@
+import * as k8s from '@kubernetes/client-node';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl create resourcequota my-quota --hard=pods=3`.
+
+try {
+    const quota = {
+        metadata: {
+            name: 'my-quota',
+        },
+        spec: {
+            hard: {
+                pods: '3',
+            },
+        },
+    };
+    const createdQuota = await k8sApi.createNamespacedResourceQuota({
+        namespace: 'default',
+        body: quota,
+    });
+
+    console.log('Created quota:', createdQuota);
+} catch (err) {
+    console.error(err);
+}

--- a/examples/kubectl/equivalents/resourceQuota-list.js
+++ b/examples/kubectl/equivalents/resourceQuota-list.js
@@ -1,0 +1,16 @@
+import * as k8s from '@kubernetes/client-node';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+// This code is the JavaScript equivalent of `kubectl get resourcequotas --all-namespaces`.
+
+try {
+    const resourceQuotas = await k8sApi.listResourceQuotaForAllNamespaces();
+
+    resourceQuotas.items.forEach((quota) => console.log(quota.metadata.name));
+} catch (err) {
+    console.error(err);
+}


### PR DESCRIPTION
This commit ports the remaining examples from the master branch to the main branch.

Fixes: https://github.com/kubernetes-client/javascript/issues/1907