### PR TITLE
websocket: do not close when protocol supports it

### DIFF
--- a/src/web-socket-handler.ts
+++ b/src/web-socket-handler.ts
@@ -96,6 +96,7 @@ export class WebSocketHandler implements WebSocketInterface {
                 buff.writeUint8(this.CloseStream, 0);
                 buff.writeUint8(this.StdinStream, 1);
                 ws.send(buff);
+                return;
             }
             ws.close();
         });

--- a/src/web-socket-handler_test.ts
+++ b/src/web-socket-handler_test.ts
@@ -404,8 +404,10 @@ describe('V5 protocol support', () => {
             send: (data) => {
                 sent = data;
             },
-            close: () => {},
-        } as WebSocket;
+            close: () => {
+                throw new Error('should not be called');
+            },
+        } as unknown as WebSocket;
         const stdinStream = new ReadableStreamBuffer();
         WebSocketHandler.handleStandardInput(ws, stdinStream);
         stdinStream.emit('end');


### PR DESCRIPTION
This commit updates the WebSocket handler to not call `ws.close()` when stdin is closed but the ws protocol already supports closing (v5 protocol for example).