### PR TITLE
chore: migrate dependabot config from master branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'daily'
+          time: '02:00'
+    - package-ecosystem: 'npm'
+      directory: '/'
+      target-branch: 'master'
+      schedule:
+          interval: 'daily'
+          time: '01:00'
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'daily'
+          time: '03:00'


### PR DESCRIPTION
This commit moves the dependabot config from the master branch to the main branch. I noticed that it seemed like dependabot PRs had slowed down recently, even after the holiday season.

Current output of npm outdated:
```
$ npm outdated
npm warn config init.author.name Use `--init-author-name` instead.
npm warn config init.author.email Use `--init-author-email` instead.
npm warn config init.author.url Use `--init-author-url` instead.
Package            Current   Wanted   Latest  Location                        Depended by
@types/node        22.10.2  22.10.5  22.10.5  node_modules/@types/node        javascript
@types/node-fetch   2.6.11   2.6.12   2.6.12  node_modules/@types/node-fetch  javascript
node-fetch           2.6.9    2.7.0    3.3.2  node_modules/node-fetch         javascript
tslint               6.1.3    6.1.3   5.20.1  node_modules/tslint             javascript
typedoc             0.27.5   0.27.6   0.27.6  node_modules/typedoc            javascript
typescript           5.7.2    5.7.3    5.7.3  node_modules/typescript         javascript
```