### PR TITLE
deps: remove whatwg-url override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3081,6 +3081,28 @@
                 }
             }
         },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3358,6 +3380,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3849,17 +3872,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/tr46": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-            "dependencies": {
-                "punycode": "^2.3.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/ts-api-utils": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
@@ -4036,26 +4048,6 @@
             },
             "engines": {
                 "node": ">=10.12.0"
-            }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-            "dependencies": {
-                "tr46": "^4.1.1",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/word-wrap": {
@@ -6247,7 +6239,28 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
             "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
             "requires": {
-                "whatwg-url": "12.0.1"
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
             }
         },
         "normalize-path": {
@@ -6432,7 +6445,8 @@
         "punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true
         },
         "punycode.js": {
             "version": "2.3.1",
@@ -6739,14 +6753,6 @@
                 "is-number": "^7.0.0"
             }
         },
-        "tr46": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-            "requires": {
-                "punycode": "^2.3.0"
-            }
-        },
         "ts-api-utils": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
@@ -6868,20 +6874,6 @@
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
                 "convert-source-map": "^2.0.0"
-            }
-        },
-        "webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-        },
-        "whatwg-url": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-            "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
-            "requires": {
-                "tr46": "^4.1.1",
-                "webidl-conversions": "^7.0.0"
             }
         },
         "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -114,8 +114,5 @@
         "trailingComma": "all",
         "singleQuote": true,
         "arrowParens": "always"
-    },
-    "overrides": {
-        "whatwg-url@<12.0.1": "12.0.1"
     }
 }


### PR DESCRIPTION
This commit removes the final override from the package.json file. The whatwg-url override was added to silence Node core deprecation warning DEP0040. While this silences the warning in the CI, it does not help users of this module.

I have also opened https://github.com/nodejs/node/pull/56632. If landed, that will make the warning go away for users of this library.