### PR TITLE
test: replace chai with node:assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Run `npm run lint` or install an editor plugin.
 
 # Testing
 
-Tests are written using the [Chai](http://chaijs.com/) library. See
+Tests are written using the [Mocha](https://mochajs.org/) test runner and
+[`node:assert`](https://nodejs.org/api/assert.html) assertion library. See
 [`config_test.ts`](./src/config_test.ts) for an example.
 
 To run tests, execute the following:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,6 @@ export default tseslint.config(
             '@typescript-eslint/no-empty-object-type': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-unused-expressions': 'off',
             '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
         },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,13 +31,9 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.18.0",
-                "@types/chai": "^5.0.0",
-                "@types/chai-as-promised": "^8.0.1",
                 "@types/mocha": "^10.0.1",
                 "@types/mock-fs": "^4.13.1",
                 "c8": "^10.0.0",
-                "chai": "^5.1.2",
-                "chai-as-promised": "^8.0.0",
                 "eslint": "^9.18.0",
                 "husky": "^9.0.6",
                 "mocha": "^11.0.1",
@@ -903,30 +899,6 @@
             "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
             "dev": true
         },
-        "node_modules/@types/chai": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz",
-            "integrity": "sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==",
-            "dev": true,
-            "dependencies": {
-                "@types/deep-eql": "*"
-            }
-        },
-        "node_modules/@types/chai-as-promised": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-8.0.1.tgz",
-            "integrity": "sha512-dAlDhLjJlABwAVYObo9TPWYTRg9NaQM5CXeaeJYcYAkvzUf0JRLIiog88ao2Wqy/20WUnhbbUZcgvngEbJ3YXQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/chai": "*"
-            }
-        },
-        "node_modules/@types/deep-eql": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-            "dev": true
-        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1332,15 +1304,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/assertion-error": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1431,34 +1394,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/chai": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-            "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
-            "dev": true,
-            "dependencies": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/chai-as-promised": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.1.tgz",
-            "integrity": "sha512-OIEJtOL8xxJSH8JJWbIoRjybbzR52iFuDHuF8eb+nTPD6tgXLjRqsgnUGqQfFODxYvq5QdirT0pN9dZ0+Gz6rA==",
-            "dev": true,
-            "dependencies": {
-                "check-error": "^2.0.0"
-            },
-            "peerDependencies": {
-                "chai": ">= 2.1.2 < 6"
-            }
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1487,15 +1422,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -1635,15 +1561,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -2648,12 +2565,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/loupe": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-            "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
-            "dev": true
-        },
         "node_modules/lru-cache": {
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -3274,15 +3185,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/pathval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 14.16"
             }
         },
         "node_modules/picocolors": {
@@ -4694,30 +4596,6 @@
             "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
             "dev": true
         },
-        "@types/chai": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz",
-            "integrity": "sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==",
-            "dev": true,
-            "requires": {
-                "@types/deep-eql": "*"
-            }
-        },
-        "@types/chai-as-promised": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-8.0.1.tgz",
-            "integrity": "sha512-dAlDhLjJlABwAVYObo9TPWYTRg9NaQM5CXeaeJYcYAkvzUf0JRLIiog88ao2Wqy/20WUnhbbUZcgvngEbJ3YXQ==",
-            "dev": true,
-            "requires": {
-                "@types/chai": "*"
-            }
-        },
-        "@types/deep-eql": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-            "dev": true
-        },
         "@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -4995,12 +4873,6 @@
                 "picomatch": "^2.0.4"
             }
         },
-        "assertion-error": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-            "dev": true
-        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5066,28 +4938,6 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
-        "chai": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-            "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
-            "dev": true,
-            "requires": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
-            }
-        },
-        "chai-as-promised": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.1.tgz",
-            "integrity": "sha512-OIEJtOL8xxJSH8JJWbIoRjybbzR52iFuDHuF8eb+nTPD6tgXLjRqsgnUGqQfFODxYvq5QdirT0pN9dZ0+Gz6rA==",
-            "dev": true,
-            "requires": {
-                "check-error": "^2.0.0"
-            }
-        },
         "chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5108,12 +4958,6 @@
                     }
                 }
             }
-        },
-        "check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-            "dev": true
         },
         "chokidar": {
             "version": "3.5.3",
@@ -5213,12 +5057,6 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
-        },
-        "deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -5923,12 +5761,6 @@
                 "is-unicode-supported": "^0.1.0"
             }
         },
-        "loupe": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-            "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
-            "dev": true
-        },
         "lru-cache": {
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -6382,12 +6214,6 @@
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             }
-        },
-        "pathval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
-            "dev": true
         },
         "picocolors": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -80,13 +80,9 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.18.0",
-        "@types/chai": "^5.0.0",
-        "@types/chai-as-promised": "^8.0.1",
         "@types/mocha": "^10.0.1",
         "@types/mock-fs": "^4.13.1",
         "c8": "^10.0.0",
-        "chai": "^5.1.2",
-        "chai-as-promised": "^8.0.0",
         "eslint": "^9.18.0",
         "husky": "^9.0.6",
         "mocha": "^11.0.1",

--- a/src/attach_test.ts
+++ b/src/attach_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { strictEqual } from 'node:assert';
 import WebSocket from 'isomorphic-ws';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, anything, capture, instance, mock, verify, when } from 'ts-mockito';
@@ -73,7 +73,7 @@ describe('Attach', () => {
             await attach.attach(namespace, pod, container, osStream, errStream, isStream, false);
             const [, , outputFn] = capture(fakeWebSocketInterface.connect).last();
 
-            expect(outputFn).to.not.be.null;
+            strictEqual(typeof outputFn, 'function');
 
             // this is redundant but needed for the compiler, sigh...
             if (!outputFn) {
@@ -83,18 +83,18 @@ describe('Attach', () => {
             let buffer = Buffer.alloc(1024, 10);
 
             outputFn(WebSocketHandler.StdoutStream, buffer);
-            expect(osStream.size()).to.equal(1024);
+            strictEqual(osStream.size(), 1024);
             let buff = osStream.getContents() as Buffer;
             for (let i = 0; i < 1024; i++) {
-                expect(buff[i]).to.equal(10);
+                strictEqual(buff[i], 10);
             }
 
             buffer = Buffer.alloc(1024, 20);
             outputFn(WebSocketHandler.StderrStream, buffer);
-            expect(errStream.size()).to.equal(1024);
+            strictEqual(errStream.size(), 1024);
             buff = errStream.getContents() as Buffer;
             for (let i = 0; i < 1024; i++) {
-                expect(buff[i]).to.equal(20);
+                strictEqual(buff[i], 20);
             }
 
             const initialTerminalSize: TerminalSize = { height: 0, width: 0 };

--- a/src/azure_auth_test.ts
+++ b/src/azure_auth_test.ts
@@ -1,5 +1,4 @@
-import { use, expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { rejects, strictEqual } from 'node:assert';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,8 +8,6 @@ import { KubeConfig } from './config.js';
 import { HttpMethod, RequestContext } from './index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-use(chaiAsPromised);
 
 describe('AzureAuth', () => {
     const testUrl1 = 'https://test1.com';
@@ -26,7 +23,7 @@ describe('AzureAuth', () => {
             },
         } as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(true);
+        strictEqual(auth.isAuthProvider(user), true);
     });
 
     it('should be false for other user', () => {
@@ -36,13 +33,13 @@ describe('AzureAuth', () => {
             },
         } as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(false);
+        strictEqual(auth.isAuthProvider(user), false);
     });
 
     it('should be false for null user.authProvider', () => {
         const user = {} as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(false);
+        strictEqual(auth.isAuthProvider(user), false);
     });
 
     it('should populate from auth provider', async () => {
@@ -63,12 +60,11 @@ describe('AzureAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
 
         requestContext.setHeaderParam('Host', 'foo.com');
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders().Authorization).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders().Authorization, `Bearer ${token}`);
     });
 
     it('should populate from auth provider without expiry', async () => {
@@ -88,8 +84,7 @@ describe('AzureAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
 
     it('should populate rejectUnauthorized=false when skipTLSVerify is set', async () => {
@@ -110,7 +105,7 @@ describe('AzureAuth', () => {
 
         await config.applySecurityAuthentication(requestContext);
         // @ts-expect-error
-        expect(requestContext.getAgent().options.rejectUnauthorized).to.equal(false);
+        strictEqual(requestContext.getAgent().options.rejectUnauthorized, false);
     });
 
     it('should not set rejectUnauthorized if skipTLSVerify is not set', async () => {
@@ -133,10 +128,10 @@ describe('AzureAuth', () => {
 
         await config.applySecurityAuthentication(requestContext);
         // @ts-expect-error
-        expect(requestContext.getAgent().options.rejectUnauthorized).to.equal(undefined);
+        strictEqual(requestContext.getAgent().options.rejectUnauthorized, undefined);
     });
 
-    it('should throw with expired token and no cmd', () => {
+    it('should throw with expired token and no cmd', async () => {
         const config = new KubeConfig();
         config.loadFromClusterAndUser(
             { skipTLSVerify: false } as Cluster,
@@ -151,12 +146,12 @@ describe('AzureAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
-        return expect(config.applySecurityAuthentication(requestContext)).to.eventually.be.rejectedWith(
-            'Token is expired!',
-        );
+        await rejects(config.applySecurityAuthentication(requestContext), {
+            message: 'Token is expired!',
+        });
     });
 
-    it('should throw with bad command', () => {
+    it('should throw with bad command', async () => {
         const config = new KubeConfig();
         config.loadFromClusterAndUser(
             { skipTLSVerify: false } as Cluster,
@@ -173,9 +168,9 @@ describe('AzureAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
-        return expect(config.applySecurityAuthentication(requestContext)).to.eventually.be.rejectedWith(
-            /Failed to refresh token/,
-        );
+        await rejects(config.applySecurityAuthentication(requestContext), {
+            message: /Failed to refresh token/,
+        });
     });
 
     it('should exec when no cmd and token is not expired', async () => {
@@ -224,8 +219,7 @@ describe('AzureAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
 
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
     it('should exec without access-token', async () => {
         // TODO: fix this test for Windows
@@ -252,8 +246,7 @@ describe('AzureAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
 
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
     it('should exec without access-token', async () => {
         // TODO: fix this test for Windows
@@ -280,8 +273,7 @@ describe('AzureAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
 
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
     it('should exec succesfully with spaces in cmd', async () => {
         // TODO: fix this test for Windows
@@ -308,7 +300,6 @@ describe('AzureAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
 
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
 });

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -197,7 +197,7 @@ describe('KubeConfig', () => {
         });
         it('should fail to load a missing kubeconfig file', () => {
             const kc = new KubeConfig();
-            throws(kc.loadFromFile.bind('missing.yaml'));
+            throws(() => kc.loadFromFile('missing.yaml'));
         });
 
         describe('filter vs throw tests', () => {

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -1,7 +1,4 @@
-import { expect, use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-use(chaiAsPromised);
-
+import { rejects, strictEqual } from 'node:assert';
 import https from 'node:https';
 import { OutgoingHttpHeaders } from 'node:http';
 
@@ -15,22 +12,22 @@ describe('ExecAuth', () => {
         const auth = new ExecAuth();
 
         const unk: unknown = null;
-        expect(auth.isAuthProvider(unk as User)).to.be.false;
+        strictEqual(auth.isAuthProvider(unk as User), false);
 
         const empty = {} as User;
-        expect(auth.isAuthProvider(empty)).to.be.false;
+        strictEqual(auth.isAuthProvider(empty), false);
 
         const exec = {
             exec: {},
         } as User;
-        expect(auth.isAuthProvider(exec)).to.be.true;
+        strictEqual(auth.isAuthProvider(exec), true);
 
         const execName = {
             authProvider: {
                 name: 'exec',
             },
         } as User;
-        expect(auth.isAuthProvider(execName)).to.be.true;
+        strictEqual(auth.isAuthProvider(execName), true);
 
         const execConfig = {
             authProvider: {
@@ -39,7 +36,7 @@ describe('ExecAuth', () => {
                 },
             },
         } as User;
-        expect(auth.isAuthProvider(execConfig)).to.be.true;
+        strictEqual(auth.isAuthProvider(execConfig), true);
 
         const azureConfig = {
             authProvider: {
@@ -49,7 +46,7 @@ describe('ExecAuth', () => {
                 },
             },
         } as User;
-        expect(auth.isAuthProvider(azureConfig)).to.be.false;
+        strictEqual(auth.isAuthProvider(azureConfig), false);
     });
 
     it('should correctly exec', async () => {
@@ -96,7 +93,7 @@ describe('ExecAuth', () => {
             },
             opts,
         );
-        expect(opts.headers.Authorization).to.equal('Bearer foo');
+        strictEqual(opts.headers.Authorization, 'Bearer foo');
     });
 
     it('should correctly exec for certs', async () => {
@@ -150,9 +147,9 @@ describe('ExecAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.be.undefined;
-        expect(opts.cert).to.equal('foo');
-        expect(opts.key).to.equal('bar');
+        strictEqual(opts.headers.Authorization, undefined);
+        strictEqual(opts.cert, 'foo');
+        strictEqual(opts.key, 'bar');
     });
 
     it('should correctly exec and cache', async () => {
@@ -210,21 +207,21 @@ describe('ExecAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${tokenValue}`);
-        expect(execCount).to.equal(1);
+        strictEqual(opts.headers.Authorization, `Bearer ${tokenValue}`);
+        strictEqual(execCount, 1);
 
         // old token should be expired, set expiration for the new token for the future.
         expire = '29 Mar 2095 00:00:00 GMT';
         tokenValue = 'bar';
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${tokenValue}`);
-        expect(execCount).to.equal(2);
+        strictEqual(opts.headers.Authorization, `Bearer ${tokenValue}`);
+        strictEqual(execCount, 2);
 
         // Should use cached token, execCount should stay at two, token shouldn't change
         tokenValue = 'baz';
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal('Bearer bar');
-        expect(execCount).to.equal(2);
+        strictEqual(opts.headers.Authorization, 'Bearer bar');
+        strictEqual(execCount, 2);
     });
 
     it('should return null on no exec info', async () => {
@@ -233,10 +230,10 @@ describe('ExecAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         await auth.applyAuthentication({} as User, opts);
-        expect(opts.headers.Authorization).to.be.undefined;
+        strictEqual(opts.headers.Authorization, undefined);
     });
 
-    it('should throw on spawnSync errors', () => {
+    it('should throw on spawnSync errors', async () => {
         // TODO: fix this test for Windows
         if (process.platform === 'win32') {
             return;
@@ -288,7 +285,7 @@ describe('ExecAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         const promise = auth.applyAuthentication(user, opts);
-        return expect(promise).to.eventually.be.rejected.and.not.instanceOf(TypeError);
+        await rejects(promise, { name: 'Error' });
     });
 
     it('should throw on exec errors', () => {
@@ -338,7 +335,7 @@ describe('ExecAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         const promise = auth.applyAuthentication(user, opts);
-        return expect(promise).to.eventually.be.rejected;
+        return rejects(promise);
     });
 
     it('should exec with env vars', async () => {
@@ -396,9 +393,9 @@ describe('ExecAuth', () => {
             },
             opts,
         );
-        expect(optsOut.env!.foo).to.equal('bar');
-        expect(optsOut.env!.PATH).to.equal(process.env.PATH);
-        expect(optsOut.env!.BLABBLE).to.equal(process.env.BLABBLE);
+        strictEqual(optsOut.env!.foo, 'bar');
+        strictEqual(optsOut.env!.PATH, process.env.PATH);
+        strictEqual(optsOut.env!.BLABBLE, process.env.BLABBLE);
     });
 
     it('should handle empty headers array correctly', async () => {
@@ -445,6 +442,6 @@ describe('ExecAuth', () => {
             },
             opts,
         );
-        expect(opts.headers?.Authorization).to.equal('Bearer foo');
+        strictEqual(opts.headers?.Authorization, 'Bearer foo');
     });
 });

--- a/src/exec_test.ts
+++ b/src/exec_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { deepStrictEqual, strictEqual } from 'node:assert';
 import WebSocket from 'isomorphic-ws';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, anything, capture, instance, mock, verify, when } from 'ts-mockito';
@@ -95,7 +95,7 @@ describe('Exec', () => {
 
             const [, , outputFn] = capture(fakeWebSocketInterface.connect).last();
 
-            expect(outputFn).to.not.be.null;
+            strictEqual(typeof outputFn, 'function');
 
             // this is redundant but needed for the compiler, sigh...
             if (!outputFn) {
@@ -105,18 +105,18 @@ describe('Exec', () => {
             let buffer = Buffer.alloc(1024, 10);
 
             outputFn(WebSocketHandler.StdoutStream, buffer);
-            expect(osStream.size()).to.equal(1024);
+            strictEqual(osStream.size(), 1024);
             let buff = osStream.getContents() as Buffer;
             for (let i = 0; i < 1024; i++) {
-                expect(buff[i]).to.equal(10);
+                strictEqual(buff[i], 10);
             }
 
             buffer = Buffer.alloc(1024, 20);
             outputFn(WebSocketHandler.StderrStream, buffer);
-            expect(errStream.size()).to.equal(1024);
+            strictEqual(errStream.size(), 1024);
             buff = errStream.getContents() as Buffer;
             for (let i = 0; i < 1024; i++) {
-                expect(buff[i]).to.equal(20);
+                strictEqual(buff[i], 20);
             }
 
             const initialTerminalSize: TerminalSize = { height: 0, width: 0 };
@@ -148,7 +148,7 @@ describe('Exec', () => {
                 message: 'this is a test',
             } as V1Status;
             outputFn(WebSocketHandler.StatusStream, Buffer.from(JSON.stringify(statusIn)));
-            expect(statusOut).to.deep.equal(statusIn);
+            deepStrictEqual(statusOut, statusIn);
 
             const closePromise = callAwaiter.awaitCall('close');
             isStream.stop();

--- a/src/file_auth_test.ts
+++ b/src/file_auth_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { strictEqual } from 'node:assert';
 import { OutgoingHttpHeaders } from 'node:http';
 import https from 'node:https';
 import mockfs from 'mock-fs';
@@ -28,7 +28,7 @@ describe('FileAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${token}`);
+        strictEqual(opts.headers.Authorization, `Bearer ${token}`);
         mockfs.restore();
     });
     it('should refresh when expired', async () => {
@@ -53,7 +53,7 @@ describe('FileAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${token}`);
+        strictEqual(opts.headers.Authorization, `Bearer ${token}`);
         mockfs.restore();
     });
     it('should claim correctly', async () => {
@@ -77,13 +77,13 @@ describe('FileAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
 
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${token}`);
+        strictEqual(opts.headers.Authorization, `Bearer ${token}`);
 
         // Set the file to non-existent, but shouldn't matter b/c token is cached.
         user.authProvider.config.tokenFile = '/non/existent/file/token.txt';
 
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${token}`);
+        strictEqual(opts.headers.Authorization, `Bearer ${token}`);
         mockfs.restore();
     });
 });

--- a/src/gcp_auth_test.ts
+++ b/src/gcp_auth_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { rejects, strictEqual } from 'node:assert';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -24,7 +24,7 @@ describe('GoogleCloudPlatformAuth', () => {
             },
         } as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(true);
+        strictEqual(auth.isAuthProvider(user), true);
     });
 
     it('should be false for other user', () => {
@@ -34,13 +34,13 @@ describe('GoogleCloudPlatformAuth', () => {
             },
         } as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(false);
+        strictEqual(auth.isAuthProvider(user), false);
     });
 
     it('should be false for null user.authProvider', () => {
         const user = {} as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(false);
+        strictEqual(auth.isAuthProvider(user), false);
     });
 
     it('should populate from auth provider', async () => {
@@ -61,14 +61,11 @@ describe('GoogleCloudPlatformAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        if (requestContext.getHeaders()) {
-            expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
-        }
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
         requestContext.setUrl('http://www.foo.com');
         //opts.headers.Host = 'foo.com';
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
+        strictEqual(requestContext.getHeaders()['Authorization'], `Bearer ${token}`);
     });
 
     it('should populate from auth provider without expirty', async () => {
@@ -88,10 +85,7 @@ describe('GoogleCloudPlatformAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        if (requestContext.getHeaders()) {
-            expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
-        }
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
 
     it('should populate rejectUnauthorized=false when skipTLSVerify is set', async () => {
@@ -114,7 +108,7 @@ describe('GoogleCloudPlatformAuth', () => {
 
         // @ts-expect-error
         const agent: Agent = requestContext.getAgent();
-        expect(agent.options.rejectUnauthorized).to.equal(false);
+        strictEqual(agent.options.rejectUnauthorized, false);
     });
 
     it('should not set rejectUnauthorized if skipTLSVerify is not set', async () => {
@@ -136,7 +130,7 @@ describe('GoogleCloudPlatformAuth', () => {
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()['rejectUnauthorized']).to.equal(undefined);
+        strictEqual(requestContext.getHeaders()['rejectUnauthorized'], undefined);
     });
 
     it('should throw with expired token and no cmd', () => {
@@ -154,9 +148,9 @@ describe('GoogleCloudPlatformAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
 
-        return expect(config.applySecurityAuthentication(requestContext)).to.eventually.be.rejectedWith(
-            'Token is expired!',
-        );
+        return rejects(config.applySecurityAuthentication(requestContext), {
+            message: 'Token is expired!',
+        });
     });
 
     it('should throw with bad command', () => {
@@ -175,9 +169,7 @@ describe('GoogleCloudPlatformAuth', () => {
             } as User,
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
-        return expect(config.applySecurityAuthentication(requestContext)).to.eventually.be.rejectedWith(
-            /Failed to refresh token/,
-        );
+        return rejects(config.applySecurityAuthentication(requestContext), /Failed to refresh token/);
     });
 
     it('should exec with expired token', async () => {
@@ -205,10 +197,7 @@ describe('GoogleCloudPlatformAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        if (requestContext.getHeaders()) {
-            expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
-        }
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
     it('should exec without access-token', async () => {
         // TODO: fix this test for Windows
@@ -234,10 +223,7 @@ describe('GoogleCloudPlatformAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        if (requestContext.getHeaders()) {
-            expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
-        }
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
     it('should exec without access-token', async () => {
         // TODO: fix this test for Windows
@@ -263,10 +249,7 @@ describe('GoogleCloudPlatformAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        if (requestContext.getHeaders()) {
-            expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
-        }
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
     it('should exec succesfully with spaces in cmd', async () => {
         // TODO: fix this test for Windows
@@ -292,9 +275,6 @@ describe('GoogleCloudPlatformAuth', () => {
         );
         const requestContext = new RequestContext(testUrl1, HttpMethod.GET);
         await config.applySecurityAuthentication(requestContext);
-        expect(requestContext.getHeaders()).to.not.be.undefined;
-        if (requestContext.getHeaders()) {
-            expect(requestContext.getHeaders()['Authorization']).to.equal(`Bearer ${token}`);
-        }
+        strictEqual(requestContext.getHeaders()?.['Authorization'], `Bearer ${token}`);
     });
 });

--- a/src/health_test.ts
+++ b/src/health_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { rejects, strictEqual } from 'node:assert';
 import nock from 'nock';
 
 import { KubeConfig } from './config.js';
@@ -10,7 +10,7 @@ describe('Health', () => {
         it('should throw an error if no current active cluster', async () => {
             const kc = new KubeConfig();
             const health = new Health(kc);
-            await expect(health.livez({})).to.be.rejectedWith('No currently active cluster');
+            await rejects(health.livez({}), { message: 'No currently active cluster' });
         });
 
         it('should return true if /livez returns with status 200', async () => {
@@ -30,7 +30,7 @@ describe('Health', () => {
             const health = new Health(kc);
 
             const r = await health.livez({});
-            expect(r).to.be.true;
+            strictEqual(r, true);
             scope.done();
         });
 
@@ -51,7 +51,7 @@ describe('Health', () => {
             const health = new Health(kc);
 
             const r = await health.livez({});
-            expect(r).to.be.false;
+            strictEqual(r, false);
             scope.done();
         });
 
@@ -74,7 +74,7 @@ describe('Health', () => {
             const health = new Health(kc);
 
             const r = await health.livez({});
-            expect(r).to.be.true;
+            strictEqual(r, true);
             scope.done();
         });
 
@@ -97,7 +97,7 @@ describe('Health', () => {
             const health = new Health(kc);
 
             const r = await health.livez({});
-            expect(r).to.be.false;
+            strictEqual(r, false);
             scope.done();
         });
 
@@ -120,7 +120,7 @@ describe('Health', () => {
             const health = new Health(kc);
 
             const r = await health.livez({});
-            expect(r).to.be.true;
+            strictEqual(r, true);
             scope.done();
         });
 
@@ -141,7 +141,7 @@ describe('Health', () => {
             scope.get('/livez').replyWithError(new Error('an error'));
             const health = new Health(kc);
 
-            await expect(health.livez({})).to.be.rejectedWith('Error occurred in health request');
+            await rejects(health.livez({}), { message: 'Error occurred in health request' });
             scope.done();
         });
     });

--- a/src/integration_test.ts
+++ b/src/integration_test.ts
@@ -1,16 +1,13 @@
-import { expect, use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { deepEqual } from 'node:assert';
 import nock from 'nock';
 
 import { CoreV1Api } from './api.js';
 import { KubeConfig } from './config.js';
 import { Cluster, User } from './config_types.js';
 
-use(chaiAsPromised);
-
 describe('FullRequest', () => {
     describe('getPods', () => {
-        it('should get pods successfully', () => {
+        it('should get pods successfully', async () => {
             const kc = new KubeConfig();
             const cluster = {
                 name: 'foo',
@@ -41,9 +38,9 @@ describe('FullRequest', () => {
                 .get('/api/v1/namespaces/default/pods')
                 .reply(200, result);
 
-            const promise = k8sApi.listNamespacedPod({ namespace: 'default' });
+            const list = await k8sApi.listNamespacedPod({ namespace: 'default' });
 
-            return expect(promise).to.eventually.deep.equals(result);
+            return deepEqual(list, result);
         });
     });
 });

--- a/src/log_test.ts
+++ b/src/log_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { strictEqual, throws } from 'node:assert';
 import { AddOptionsToSearchParams, LogOptions } from './log.js';
 
 describe('Log', () => {
@@ -15,28 +15,28 @@ describe('Log', () => {
                 timestamps: true,
             };
             AddOptionsToSearchParams(options, searchParams);
-            expect(searchParams.get('follow')).to.equal('true');
-            expect(searchParams.get('limitBytes')).to.equal('100');
-            expect(searchParams.get('pretty')).to.equal('true');
-            expect(searchParams.get('previous')).to.equal('true');
-            expect(searchParams.get('sinceSeconds')).to.equal('1');
-            expect(searchParams.get('tailLines')).to.equal('1');
-            expect(searchParams.get('timestamps')).to.equal('true');
+            strictEqual(searchParams.get('follow'), 'true');
+            strictEqual(searchParams.get('limitBytes'), '100');
+            strictEqual(searchParams.get('pretty'), 'true');
+            strictEqual(searchParams.get('previous'), 'true');
+            strictEqual(searchParams.get('sinceSeconds'), '1');
+            strictEqual(searchParams.get('tailLines'), '1');
+            strictEqual(searchParams.get('timestamps'), 'true');
 
             const sinceTime = new Date().toISOString();
             searchParams = new URLSearchParams();
             options = { sinceTime };
             AddOptionsToSearchParams(options, searchParams);
-            expect(searchParams.get('sinceTime')).to.equal(sinceTime);
+            strictEqual(searchParams.get('sinceTime'), sinceTime);
         });
         it('should use defaults for', () => {
             const searchParams = new URLSearchParams();
             const options: LogOptions = {};
             AddOptionsToSearchParams(options, searchParams);
-            expect(searchParams.get('follow')).to.equal('false');
-            expect(searchParams.get('pretty')).to.equal('false');
-            expect(searchParams.get('previous')).to.equal('false');
-            expect(searchParams.get('timestamps')).to.equal('false');
+            strictEqual(searchParams.get('follow'), 'false');
+            strictEqual(searchParams.get('pretty'), 'false');
+            strictEqual(searchParams.get('previous'), 'false');
+            strictEqual(searchParams.get('timestamps'), 'false');
         });
         it('sinceTime and sinceSeconds cannot be used together', () => {
             const searchParams = new URLSearchParams();
@@ -45,9 +45,9 @@ describe('Log', () => {
                 sinceSeconds: 1,
                 sinceTime,
             };
-            expect(() => {
+            throws(() => {
                 AddOptionsToSearchParams(options, searchParams);
-            }).to.throw('at most one of sinceTime or sinceSeconds may be specified');
+            }, /at most one of sinceTime or sinceSeconds may be specified/);
         });
     });
 });

--- a/src/object_test.ts
+++ b/src/object_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert';
 import nock from 'nock';
 import { Configuration, V1APIResource, V1APIResourceList, V1Secret } from './api.js';
 import { KubeConfig } from './config.js';
@@ -19,8 +19,7 @@ describe('KubernetesObject', () => {
             const kc = new KubeConfig();
             kc.loadFromOptions(testConfigOptions);
             const c = KubernetesObjectApi.makeApiClient(kc);
-            expect(c).to.be.ok;
-            expect((c as any).defaultNamespace).to.equal('default');
+            strictEqual((c as any).defaultNamespace, 'default');
         });
 
         it('should set the default namespace from context', () => {
@@ -32,8 +31,7 @@ describe('KubernetesObject', () => {
                 currentContext: 'dischord',
             });
             const c = KubernetesObjectApi.makeApiClient(kc);
-            expect(c).to.be.ok;
-            expect((c as any).defaultNamespace).to.equal('straight-edge');
+            strictEqual((c as any).defaultNamespace, 'straight-edge');
         });
     });
 
@@ -492,7 +490,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'patch');
-            expect(r).to.equal('/api/v1/namespaces/fugazi/services/repeater');
+            strictEqual(r, '/api/v1/namespaces/fugazi/services/repeater');
             scope.done();
         });
 
@@ -509,7 +507,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'patch');
-            expect(r).to.equal('/api/v1/namespaces/fugazi/serviceaccounts/repeater');
+            strictEqual(r, '/api/v1/namespaces/fugazi/serviceaccounts/repeater');
             scope.done();
         });
 
@@ -533,7 +531,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'patch');
-            expect(r).to.equal('/api/v1/namespaces/straight-edge/pods/repeater');
+            strictEqual(r, '/api/v1/namespaces/straight-edge/pods/repeater');
             scope.done();
         });
 
@@ -557,7 +555,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'patch');
-            expect(r).to.equal('/api/v1/namespaces/default/pods/repeater');
+            strictEqual(r, '/api/v1/namespaces/default/pods/repeater');
             scope.done();
         });
 
@@ -574,7 +572,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'delete');
-            expect(r).to.equal('/api/v1/namespaces/repeater');
+            strictEqual(r, '/api/v1/namespaces/repeater');
             scope.done();
         });
 
@@ -591,7 +589,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'create');
-            expect(r).to.equal('/api/v1/namespaces/fugazi/services');
+            strictEqual(r, '/api/v1/namespaces/fugazi/services');
             scope.done();
         });
 
@@ -608,7 +606,7 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'create');
-            expect(r).to.equal('/api/v1/namespaces');
+            strictEqual(r, '/api/v1/namespaces');
             scope.done();
         });
 
@@ -626,7 +624,7 @@ describe('KubernetesObject', () => {
                 .get('/apis/apps/v1')
                 .reply(200, resourceBodies.apps, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'read');
-            expect(r).to.equal('/apis/apps/v1/namespaces/fugazi/deployments/repeater');
+            strictEqual(r, '/apis/apps/v1/namespaces/fugazi/deployments/repeater');
             scope.done();
         });
 
@@ -643,7 +641,7 @@ describe('KubernetesObject', () => {
                 .get('/apis/rbac.authorization.k8s.io/v1')
                 .reply(200, resourceBodies.rbac, contentTypeJsonHeader);
             const r = await c.specUriPath(o, 'read');
-            expect(r).to.equal('/apis/rbac.authorization.k8s.io/v1/clusterroles/repeater');
+            strictEqual(r, '/apis/rbac.authorization.k8s.io/v1/clusterroles/repeater');
             scope.done();
         });
 
@@ -761,7 +759,7 @@ describe('KubernetesObject', () => {
                 }
                 const scope = nock('https://d.i.y').get(k.p).reply(200, k.b, contentTypeJsonHeader);
                 const r = await c.specUriPath(o, 'patch');
-                expect(r).to.equal(k.e);
+                strictEqual(r, k.e);
                 scope.done();
             }
         });
@@ -876,7 +874,7 @@ describe('KubernetesObject', () => {
                 }
                 const scope = nock('https://d.i.y').get(k.p).reply(200, k.b, contentTypeJsonHeader);
                 const r = await c.specUriPath(o, 'create');
-                expect(r).to.equal(k.e);
+                strictEqual(r, k.e);
                 scope.done();
             }
         });
@@ -890,10 +888,10 @@ describe('KubernetesObject', () => {
                     namespace: 'fugazi',
                 },
             };
-            await expect(c.specUriPath(o, 'create')).to.be.rejectedWith(
-                Error,
-                'Required spec property kind is not set',
-            );
+            await rejects(c.specUriPath(o, 'create'), {
+                name: 'Error',
+                message: 'Required spec property kind is not set',
+            });
         });
 
         it('should throw an error if name required and missing', async () => {
@@ -909,10 +907,10 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
 
-            await expect(c.specUriPath(o, 'read')).to.be.rejectedWith(
-                Error,
-                'Required spec property name is not set',
-            );
+            await rejects(c.specUriPath(o, 'read'), {
+                name: 'Error',
+                message: 'Required spec property name is not set',
+            });
             scope.done();
         });
 
@@ -929,10 +927,11 @@ describe('KubernetesObject', () => {
             const scope = nock('https://d.i.y')
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
-            await expect(c.specUriPath(o, 'create')).to.be.rejectedWith(
-                Error,
-                'Unrecognized API version and kind: v1 Ingress',
-            );
+
+            await rejects(c.specUriPath(o, 'create'), {
+                name: 'Error',
+                message: 'Unrecognized API version and kind: v1 Ingress',
+            });
             scope.done();
         });
     });
@@ -945,19 +944,19 @@ describe('KubernetesObject', () => {
 
         it('should throw an error if apiVersion not set', async () => {
             for (const a of [null, undefined]) {
-                await expect(client.resource(a as unknown as string, 'Service')).to.be.rejectedWith(
-                    Error,
-                    'Required parameter apiVersion was null or undefined when calling resource',
-                );
+                await rejects(client.resource(a as unknown as string, 'Service'), {
+                    name: 'Error',
+                    message: 'Required parameter apiVersion was null or undefined when calling resource',
+                });
             }
         });
 
         it('should throw an error if kind not set', async () => {
             for (const a of [null, undefined]) {
-                await expect(client.resource('v1', a as unknown as string)).to.be.rejectedWith(
-                    Error,
-                    'Required parameter kind was null or undefined when calling resource',
-                );
+                await rejects(client.resource('v1', a as unknown as string), {
+                    name: 'Error',
+                    message: 'Required parameter kind was null or undefined when calling resource',
+                });
             }
         });
 
@@ -981,8 +980,8 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             await c.resource('v1', 'Service');
-            expect(preMiddlewareCalled).to.be.true;
-            expect(postMiddlewareCalled).to.be.true;
+            strictEqual(preMiddlewareCalled, true);
+            strictEqual(postMiddlewareCalled, true);
             scope.done();
         });
 
@@ -992,39 +991,35 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const s = await c.resource('v1', 'Service');
-            expect(s).to.be.ok;
             if (!s) {
                 throw new Error('old TypeScript compiler');
             }
-            expect(s.kind).to.equal('Service');
-            expect(s.name).to.equal('services');
-            expect(s.namespaced).to.be.true;
-            expect(c.apiVersionResourceCache).to.be.ok;
-            expect(c.apiVersionResourceCache.v1).to.be.ok;
+            strictEqual(s.kind, 'Service');
+            strictEqual(s.name, 'services');
+            strictEqual(s.namespaced, true);
+            ok(c.apiVersionResourceCache);
+            ok(c.apiVersionResourceCache.v1);
             const sa = await c.resource('v1', 'ServiceAccount');
-            expect(sa).to.be.ok;
             if (!sa) {
                 throw new Error('old TypeScript compiler');
             }
-            expect(sa.kind).to.equal('ServiceAccount');
-            expect(sa.name).to.equal('serviceaccounts');
-            expect(sa.namespaced).to.be.true;
+            strictEqual(sa.kind, 'ServiceAccount');
+            strictEqual(sa.name, 'serviceaccounts');
+            strictEqual(sa.namespaced, true);
             const p = await c.resource('v1', 'Pod');
             if (!p) {
                 throw new Error('old TypeScript compiler');
             }
-            expect(p).to.be.ok;
-            expect(p.kind).to.equal('Pod');
-            expect(p.name).to.equal('pods');
-            expect(p.namespaced).to.be.true;
+            strictEqual(p.kind, 'Pod');
+            strictEqual(p.name, 'pods');
+            strictEqual(p.namespaced, true);
             const pv = await c.resource('v1', 'PersistentVolume');
             if (!pv) {
                 throw new Error('old TypeScript compiler');
             }
-            expect(pv).to.be.ok;
-            expect(pv.kind).to.equal('PersistentVolume');
-            expect(pv.name).to.equal('persistentvolumes');
-            expect(pv.namespaced).to.be.false;
+            strictEqual(pv.kind, 'PersistentVolume');
+            strictEqual(pv.name, 'persistentvolumes');
+            strictEqual(pv.namespaced, false);
             scope.done();
         });
 
@@ -1050,16 +1045,16 @@ describe('KubernetesObject', () => {
                 .get('/api/v1')
                 .reply(200, resourceBodies.core, contentTypeJsonHeader);
             const s = await c.resource('v1', 'Service');
-            expect(s).to.be.ok;
             if (!s) {
                 throw new Error('old TypeScript compiler');
             }
-            expect(s.kind).to.equal('Service');
-            expect(s.name).to.equal('services');
-            expect(s.namespaced).to.be.true;
-            expect(c.apiVersionResourceCache).to.be.ok;
-            expect(c.apiVersionResourceCache.v1).to.be.ok;
-            expect(c.apiVersionResourceCache.v1.resources.length).to.deep.equal(
+            strictEqual(s.kind, 'Service');
+            strictEqual(s.name, 'services');
+            strictEqual(s.namespaced, true);
+            ok(c.apiVersionResourceCache);
+            ok(c.apiVersionResourceCache.v1);
+            strictEqual(
+                c.apiVersionResourceCache.v1.resources.length,
                 JSON.parse(resourceBodies.core).resources.length,
             );
             scope.done();
@@ -1678,9 +1673,10 @@ describe('KubernetesObject', () => {
             const c = await client.create(s, undefined, undefined, 'ManageField');
             (c.metadata.annotations as Record<string, string>).test = '1';
             const r = await client.replace(c, 'true');
-            expect((r.metadata.annotations as Record<string, string>).test).to.equal('1');
-            expect(parseInt((r.metadata as any).resourceVersion, 10)).to.be.greaterThan(
-                parseInt((c.metadata as any).resourceVersion, 10),
+            strictEqual((r.metadata.annotations as Record<string, string>).test, '1');
+            ok(
+                parseInt((r.metadata as any).resourceVersion, 10) >
+                    parseInt((c.metadata as any).resourceVersion, 10),
             );
             await client.delete(s, undefined, undefined, 7, undefined, 'Foreground');
             scope.done();
@@ -1714,12 +1710,12 @@ describe('KubernetesObject', () => {
                     namespace: 'default',
                 },
             });
-            expect(secret).to.be.instanceof(V1Secret);
-            expect(secret.data).to.deep.equal({
+            strictEqual(secret instanceof V1Secret, true);
+            deepStrictEqual(secret.data, {
                 key: 'value',
             });
-            expect(secret.metadata).to.be.ok;
-            expect(secret.metadata!.creationTimestamp).to.deep.equal(new Date('2022-01-01T00:00:00.000Z'));
+            ok(secret.metadata);
+            deepStrictEqual(secret.metadata!.creationTimestamp, new Date('2022-01-01T00:00:00.000Z'));
             scope.done();
         });
 
@@ -1767,11 +1763,11 @@ describe('KubernetesObject', () => {
                     namespace: 'default',
                 },
             });
-            expect(custom.spec).to.deep.equal({
+            deepStrictEqual(custom.spec, {
                 key: 'value',
             });
-            expect(custom.metadata).to.be.ok;
-            expect(custom.metadata!.creationTimestamp).to.deep.equal(new Date('2022-01-01T00:00:00.000Z'));
+            ok(custom.metadata);
+            deepStrictEqual(custom.metadata!.creationTimestamp, new Date('2022-01-01T00:00:00.000Z'));
             scope.done();
         });
 
@@ -1802,8 +1798,8 @@ describe('KubernetesObject', () => {
                 );
             const lr = await client.list<V1Secret>('v1', 'Secret', 'default');
             const items = lr.items;
-            expect(items).to.have.length(1);
-            expect(items[0]).to.be.instanceof(V1Secret);
+            strictEqual(items.length, 1);
+            strictEqual(items[0] instanceof V1Secret, true);
             scope.done();
         });
 
@@ -1846,7 +1842,7 @@ describe('KubernetesObject', () => {
                 5,
             );
             const items = lr.items;
-            expect(items).to.have.length(1);
+            strictEqual(items.length, 1);
             scope.done();
         });
     });
@@ -1865,10 +1861,10 @@ describe('KubernetesObject', () => {
                 for (const m of methods) {
                     // TODO: Figure out why Typescript barfs if we do m.call
                     const hack_m = m as any;
-                    await expect(hack_m.call(client, s)).to.be.rejectedWith(
-                        Error,
-                        'Required parameter spec was null or undefined when calling ',
-                    );
+                    await rejects(hack_m.call(client, s), {
+                        name: 'Error',
+                        message: /Required parameter spec was null or undefined when calling /,
+                    });
                 }
             }
         });
@@ -1895,7 +1891,10 @@ describe('KubernetesObject', () => {
                 },
             };
             nock('https://d.i.y');
-            await expect(client.read(s)).to.be.rejectedWith(Error, 'Nock: No match for request');
+            await rejects(client.read(s), {
+                code: 'ERR_NOCK_NO_MATCH',
+                message: /Nock: No match for request/,
+            });
         });
 
         it('should throw an error if name not valid', async () => {
@@ -1948,9 +1947,9 @@ describe('KubernetesObject', () => {
                     contentTypeJsonHeader,
                 );
 
-            await expect(client.create(s)).to.be.rejected.then((e) => {
-                expect(e).to.be.an.instanceOf(Error);
-                expect(e.code).to.equal(422);
+            await rejects(client.create(s), {
+                name: 'Error',
+                code: 422,
             });
             scope.done();
         });
@@ -1992,28 +1991,26 @@ describe('KubernetesObject', () => {
             const scope = nock('https://d.i.y')
                 .get('/apis/applications/v1')
                 .reply(404, '{}', contentTypeJsonHeader);
-            await expect(client.create(d)).to.be.rejected.then((e) => {
-                expect(e).to.be.an.instanceOf(Error);
-                expect(e.code).to.equal(404);
-                expect(e.message).to.contain(
-                    'Failed to fetch resource metadata for applications/v1/Deployment',
-                );
+            await rejects(client.create(d), {
+                name: 'Error',
+                code: 404,
+                message: /Failed to fetch resource metadata for applications\/v1\/Deployment/,
             });
             scope.done();
         });
 
         it('should throw error if no apiVersion', async () => {
-            await expect((client.list as any)(undefined, undefined)).to.be.rejectedWith(
-                Error,
-                'Required parameter apiVersion was null or undefined when calling ',
-            );
+            await rejects((client.list as any)(undefined, undefined), {
+                name: 'Error',
+                message: 'Required parameter apiVersion was null or undefined when calling list.',
+            });
         });
 
         it('should throw error if no kind', async () => {
-            await expect((client.list as any)('', undefined)).to.be.rejectedWith(
-                Error,
-                'Required parameter kind was null or undefined when calling ',
-            );
+            await rejects((client.list as any)('', undefined), {
+                name: 'Error',
+                message: 'Required parameter kind was null or undefined when calling list.',
+            });
         });
     });
 });

--- a/src/oidc_auth_test.ts
+++ b/src/oidc_auth_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { notStrictEqual, strictEqual } from 'node:assert';
 import { OutgoingHttpHeaders } from 'node:http';
 import https from 'node:https';
 import { base64url } from 'rfc4648';
@@ -24,7 +24,7 @@ describe('OIDCAuth', () => {
         const jwt = OpenIDConnectAuth.decodeJWT(
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.5mhBHqs5_DTLdINd9p5m7ZJ6XD0Xc55kIaCRY5r6HRA',
         );
-        expect(jwt).to.not.be.null;
+        notStrictEqual(jwt, null);
     });
 
     it('should correctly parse time from token', () => {
@@ -32,7 +32,7 @@ describe('OIDCAuth', () => {
         const token = makeJWT('{}', { exp: time }, 'fake');
         const timeOut = OpenIDConnectAuth.expirationFromToken(token);
 
-        expect(timeOut).to.equal(time);
+        strictEqual(timeOut, time);
     });
 
     it('should be true for oidc user', () => {
@@ -42,7 +42,7 @@ describe('OIDCAuth', () => {
             },
         } as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(true);
+        strictEqual(auth.isAuthProvider(user), true);
     });
 
     it('should be false for other user', () => {
@@ -52,13 +52,13 @@ describe('OIDCAuth', () => {
             },
         } as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(false);
+        strictEqual(auth.isAuthProvider(user), false);
     });
 
     it('should be false for null user.authProvider', () => {
         const user = {} as User;
 
-        expect(auth.isAuthProvider(user)).to.equal(false);
+        strictEqual(auth.isAuthProvider(user), false);
     });
 
     it('authorization should be undefined if token missing', async () => {
@@ -77,7 +77,7 @@ describe('OIDCAuth', () => {
         const opts = {} as https.RequestOptions;
         opts.headers = {} as OutgoingHttpHeaders;
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.be.undefined;
+        strictEqual(opts.headers.Authorization, undefined);
     });
 
     it('authorization should be undefined if client-id missing', async () => {
@@ -98,7 +98,7 @@ describe('OIDCAuth', () => {
         const opts = {} as https.RequestOptions;
         opts.headers = {} as OutgoingHttpHeaders;
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.be.undefined;
+        strictEqual(opts.headers.Authorization, undefined);
     });
 
     it('authorization should be work if client-secret missing', async () => {
@@ -118,7 +118,7 @@ describe('OIDCAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
         (auth as any).currentTokenExpiration = Date.now() / 1000 + 1000;
         await auth.applyAuthentication(user, opts, {});
-        expect(opts.headers.Authorization).to.equal('Bearer fakeToken');
+        strictEqual(opts.headers.Authorization, 'Bearer fakeToken');
     });
 
     it('authorization should be undefined if refresh-token missing', async () => {
@@ -139,7 +139,7 @@ describe('OIDCAuth', () => {
         const opts = {} as https.RequestOptions;
         opts.headers = {} as OutgoingHttpHeaders;
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.be.undefined;
+        strictEqual(opts.headers.Authorization, undefined);
     });
 
     it('authorization should work if refresh-token missing but token is unexpired', async () => {
@@ -160,7 +160,7 @@ describe('OIDCAuth', () => {
         const opts = {} as https.RequestOptions;
         opts.headers = {} as OutgoingHttpHeaders;
         await auth.applyAuthentication(user, opts);
-        expect(opts.headers.Authorization).to.equal(`Bearer ${token}`);
+        strictEqual(opts.headers.Authorization, `Bearer ${token}`);
     });
 
     it('authorization should be undefined if idp-issuer-url missing', async () => {
@@ -181,7 +181,7 @@ describe('OIDCAuth', () => {
         const opts = {} as https.RequestOptions;
         opts.headers = {} as OutgoingHttpHeaders;
         await auth.applyAuthentication(user, opts, {});
-        expect(opts.headers.Authorization).to.be.undefined;
+        strictEqual(opts.headers.Authorization, undefined);
     });
 
     it('return token when it is still active', async () => {
@@ -202,7 +202,7 @@ describe('OIDCAuth', () => {
         opts.headers = {} as OutgoingHttpHeaders;
         (auth as any).currentTokenExpiration = Date.now() / 1000 + 1000;
         await auth.applyAuthentication(user, opts, {});
-        expect(opts.headers.Authorization).to.equal('Bearer fakeToken');
+        strictEqual(opts.headers.Authorization, 'Bearer fakeToken');
     });
 
     it('return new token when the current expired', async () => {
@@ -232,10 +232,10 @@ describe('OIDCAuth', () => {
                 };
             },
         });
-        expect(opts.headers.Authorization).to.equal('Bearer newToken');
-        expect((auth as any).currentTokenExpiration).to.equal(newExpiration);
+        strictEqual(opts.headers.Authorization, 'Bearer newToken');
+        strictEqual((auth as any).currentTokenExpiration, newExpiration);
         // Check also the new refresh token sticks in the user config
-        expect(user.authProvider.config['refresh-token']).to.equal('newRefreshToken');
+        strictEqual(user.authProvider.config['refresh-token'], 'newRefreshToken');
     });
 
     it('return a new token when the its the first time we see this user', async () => {
@@ -264,7 +264,7 @@ describe('OIDCAuth', () => {
                 };
             },
         });
-        expect(opts.headers.Authorization).to.equal('Bearer newToken');
-        expect((auth as any).currentTokenExpiration).to.equal(newExpiration);
+        strictEqual(opts.headers.Authorization, 'Bearer newToken');
+        strictEqual((auth as any).currentTokenExpiration, newExpiration);
     });
 });

--- a/src/package_test.ts
+++ b/src/package_test.ts
@@ -1,5 +1,5 @@
+import { strictEqual } from 'node:assert';
 import { createRequire } from 'node:module';
-import { expect } from 'chai';
 const require = createRequire(import.meta.url);
 
 // Generic set of tests to verify the package is built and configured correctly
@@ -7,10 +7,10 @@ describe('package', () => {
     it('package-lock.json should match package.json', () => {
         const v1 = require('../package.json').version;
         const v2 = require('../package-lock.json').version;
-        expect(v1).to.equal(v2);
+        strictEqual(v1, v2);
 
         const v3 = require('../package-lock.json').packages[''].version;
-        expect(v1).to.equal(v3);
+        strictEqual(v1, v3);
     });
 
     it('package-lock should only reference npm', () => {
@@ -21,8 +21,8 @@ describe('package', () => {
             for (const key in deps.dependencies) {
                 const dep = deps.dependencies[key];
                 const resolved = new URL(dep.resolved);
-                expect(resolved.hostname).to.equal('registry.npmjs.org');
-                expect(resolved.protocol).to.equal('https:');
+                strictEqual(resolved.hostname, 'registry.npmjs.org');
+                strictEqual(resolved.protocol, 'https:');
                 validateDependencies(dep);
             }
         };

--- a/src/portforward_test.ts
+++ b/src/portforward_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { strictEqual, rejects } from 'node:assert';
 import { ReadableStreamBuffer, WritableStreamBuffer } from 'stream-buffers';
 import { anyFunction, capture, instance, mock, verify } from 'ts-mockito';
 
@@ -36,7 +36,7 @@ describe('PortForward', () => {
 
         const [, , outputFn] = capture(fakeWebSocket.connect).last();
 
-        expect(outputFn).to.not.be.null;
+        strictEqual(typeof outputFn, 'function');
         // this is redundant but needed for the compiler, sigh...
         if (!outputFn) {
             return;
@@ -48,7 +48,7 @@ describe('PortForward', () => {
 
         outputFn(0, buffer);
         // first time, drop two bytes for the port number.
-        expect(osStream.size()).to.equal(1022);
+        strictEqual(osStream.size(), 1022);
     });
 
     it('should correctly port-forward streams if err is null', async () => {
@@ -62,7 +62,7 @@ describe('PortForward', () => {
 
         const [, , outputFn] = capture(fakeWebSocket.connect).last();
 
-        expect(outputFn).to.not.be.null;
+        strictEqual(typeof outputFn, 'function');
         // this is redundant but needed for the compiler, sigh...
         if (!outputFn) {
             return;
@@ -72,7 +72,7 @@ describe('PortForward', () => {
         // error stream, drop two bytes for the port number.
         outputFn(1, buffer);
         // error stream is null, expect output to be dropped and nothing to change.
-        expect(osStream.size()).to.equal(0);
+        strictEqual(osStream.size(), 0);
     });
 
     it('should correctly port-forward streams', async () => {
@@ -87,7 +87,7 @@ describe('PortForward', () => {
 
         const [, , outputFn] = capture(fakeWebSocket.connect).last();
 
-        expect(outputFn).to.not.be.null;
+        strictEqual(typeof outputFn, 'function');
         // this is redundant but needed for the compiler, sigh...
         if (!outputFn) {
             return;
@@ -96,22 +96,22 @@ describe('PortForward', () => {
 
         outputFn(0, buffer);
         // first time, drop two bytes for the port number.
-        expect(osStream.size()).to.equal(1022);
+        strictEqual(osStream.size(), 1022);
 
         outputFn(0, buffer);
-        expect(osStream.size()).to.equal(2046);
+        strictEqual(osStream.size(), 2046);
 
         // error stream, drop two bytes for the port number.
         outputFn(1, buffer);
-        expect(errStream.size()).to.equal(1022);
+        strictEqual(errStream.size(), 1022);
 
         outputFn(1, buffer);
-        expect(errStream.size()).to.equal(2046);
+        strictEqual(errStream.size(), 2046);
 
         // unknown stream, shouldn't change anything.
         outputFn(2, buffer);
-        expect(osStream.size()).to.equal(2046);
-        expect(errStream.size()).to.equal(2046);
+        strictEqual(osStream.size(), 2046);
+        strictEqual(errStream.size(), 2046);
     });
 
     it('should throw with no ports or too many', async () => {
@@ -120,11 +120,13 @@ describe('PortForward', () => {
         const osStream = new WritableStreamBuffer();
         const isStream = new ReadableStreamBuffer();
 
-        await expect(
-            portForward.portForward('ns', 'pod', [], osStream, osStream, isStream),
-        ).to.be.rejectedWith(Error, 'You must provide at least one port to forward to.');
-        await expect(
-            portForward.portForward('ns', 'pod', [1, 2], osStream, osStream, isStream),
-        ).to.be.rejectedWith(Error, 'Only one port is currently supported for port-forward');
+        await rejects(portForward.portForward('ns', 'pod', [], osStream, osStream, isStream), {
+            name: 'Error',
+            message: 'You must provide at least one port to forward to.',
+        });
+        await rejects(portForward.portForward('ns', 'pod', [1, 2], osStream, osStream, isStream), {
+            name: 'Error',
+            message: 'Only one port is currently supported for port-forward',
+        });
     });
 });

--- a/src/serializer_test.ts
+++ b/src/serializer_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { deepEqual, deepStrictEqual } from 'node:assert';
 import { ObjectSerializer } from './serializer.js';
 
 describe('ObjectSerializer', () => {
@@ -17,7 +17,7 @@ describe('ObjectSerializer', () => {
                 },
             };
             const res = ObjectSerializer.serialize(s, 'V1Secret');
-            expect(res).to.deep.equal({
+            deepStrictEqual(res, {
                 apiVersion: 'v1',
                 kind: 'Secret',
                 metadata: {
@@ -60,7 +60,7 @@ describe('ObjectSerializer', () => {
                 },
             };
             const res = ObjectSerializer.serialize(s, 'v1alpha1MyCustomResource');
-            expect(res).to.deep.equal({
+            deepStrictEqual(res, {
                 apiVersion: 'v1alpha1',
                 kind: 'MyCustomResource',
                 metadata: {
@@ -91,7 +91,7 @@ describe('ObjectSerializer', () => {
                 key: 'value',
             };
             const res = ObjectSerializer.serialize(s, 'unknown');
-            expect(res).to.deep.equal(s);
+            deepStrictEqual(res, s);
         });
     });
 
@@ -110,7 +110,7 @@ describe('ObjectSerializer', () => {
                 },
             };
             const res = ObjectSerializer.deserialize(s, 'V1Secret');
-            expect(res).to.deep.equal({
+            deepEqual(res, {
                 apiVersion: 'v1',
                 kind: 'Secret',
                 metadata: {
@@ -138,7 +138,7 @@ describe('ObjectSerializer', () => {
                 },
             };
             const res = ObjectSerializer.deserialize(s, 'v1alpha1MyCustomResource');
-            expect(res).to.deep.equal({
+            deepEqual(res, {
                 apiVersion: 'v1alpha1',
                 kind: 'MyCustomResource',
                 metadata: {
@@ -157,7 +157,7 @@ describe('ObjectSerializer', () => {
                 key: 'value',
             };
             const res = ObjectSerializer.serialize(s, 'unknown');
-            expect(res).to.deep.equal(s);
+            deepStrictEqual(res, s);
         });
     });
 });

--- a/src/test/match-buffer.ts
+++ b/src/test/match-buffer.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { deepStrictEqual, strictEqual } from 'node:assert';
 import { RequestOptions, Agent } from 'node:https';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher.js';
 
@@ -56,9 +56,9 @@ export function assertRequestAgentsEqual(agent1: Agent, agent2: Agent): void {
         throw 'unequal agent key buffer';
     }
 
-    expect(agent1.options.passphrase).to.equal(agent2.options.passphrase);
-    expect(agent1.options.pfx).to.equal(agent2.options.pfx);
-    expect(agent1.options.rejectUnauthorized).to.equal(agent2.options.rejectUnauthorized);
+    strictEqual(agent1.options.passphrase, agent2.options.passphrase);
+    strictEqual(agent1.options.pfx, agent2.options.pfx);
+    strictEqual(agent1.options.rejectUnauthorized, agent2.options.rejectUnauthorized);
 }
 
 export function assertRequestOptionsEqual(options1: RequestOptions, options2: RequestOptions): void {
@@ -68,8 +68,8 @@ export function assertRequestOptionsEqual(options1: RequestOptions, options2: Re
     const agent2: Agent = options2.agent;
     assertRequestAgentsEqual(agent1, agent2);
 
-    expect(options1.auth).to.equal(options2.auth);
-    expect(options1.headers).to.deep.equal(options2.headers);
-    expect(options1.rejectUnauthorized).to.equal(options2.rejectUnauthorized);
-    expect(options1.servername).to.equal(options2.servername);
+    strictEqual(options1.auth, options2.auth);
+    deepStrictEqual(options1.headers, options2.headers);
+    strictEqual(options1.rejectUnauthorized, options2.rejectUnauthorized);
+    strictEqual(options1.servername, options2.servername);
 }

--- a/src/top_test.ts
+++ b/src/top_test.ts
@@ -1,8 +1,8 @@
-import { expect } from 'chai';
+import { deepEqual, deepStrictEqual, strictEqual } from 'assert';
 import nock from 'nock';
 import { KubeConfig } from './config.js';
 import { Metrics, PodMetricsList } from './metrics.js';
-import { topPods } from './top.js';
+import { CurrentResourceUsage, topPods } from './top.js';
 import { CoreV1Api, V1Pod } from './api.js';
 
 const emptyPodMetrics: PodMetricsList = {
@@ -155,7 +155,7 @@ describe('Top', () => {
                 items: [],
             });
             const result = await topPodsFunc();
-            expect(result).to.deep.equal([]);
+            deepStrictEqual(result, []);
             podMetrics.done();
             pods.done();
         });
@@ -166,7 +166,7 @@ describe('Top', () => {
                 items: [],
             });
             const result = await topPodsFunc();
-            expect(result).to.deep.equal([]);
+            deepStrictEqual(result, []);
             podMetrics.done();
             pods.done();
         });
@@ -177,18 +177,13 @@ describe('Top', () => {
                 items: podList,
             });
             const result = await topPodsFunc();
-            expect(result.length).to.equal(2);
-            expect(result[0].CPU).to.deep.equal({
-                CurrentUsage: 0.05,
-                LimitTotal: 0.1,
-                RequestTotal: 0.1,
-            });
-            expect(result[0].Memory).to.deep.equal({
-                CurrentUsage: BigInt('4005888'),
-                RequestTotal: BigInt('104857600'),
-                LimitTotal: BigInt('104857600'),
-            });
-            expect(result[0].Containers).to.deep.equal([
+            strictEqual(result.length, 2);
+            deepStrictEqual(result[0].CPU, new CurrentResourceUsage(0.05, 0.1, 0.1));
+            deepStrictEqual(
+                result[0].Memory,
+                new CurrentResourceUsage(BigInt('4005888'), BigInt('104857600'), BigInt('104857600')),
+            );
+            deepEqual(result[0].Containers, [
                 {
                     CPUUsage: {
                         CurrentUsage: 0.05,
@@ -203,17 +198,12 @@ describe('Top', () => {
                     },
                 },
             ]);
-            expect(result[1].CPU).to.deep.equal({
-                CurrentUsage: 1.4,
-                LimitTotal: 2.1,
-                RequestTotal: 2.1,
-            });
-            expect(result[1].Memory).to.deep.equal({
-                CurrentUsage: BigInt('7192576'),
-                LimitTotal: BigInt('209715200'),
-                RequestTotal: BigInt('157286400'),
-            });
-            expect(result[1].Containers).to.deep.equal([
+            deepStrictEqual(result[1].CPU, new CurrentResourceUsage(1.4, 2.1, 2.1));
+            deepStrictEqual(
+                result[1].Memory,
+                new CurrentResourceUsage(BigInt('7192576'), BigInt('157286400'), BigInt('209715200')),
+            );
+            deepEqual(result[1].Containers, [
                 {
                     CPUUsage: {
                         CurrentUsage: 0,
@@ -251,18 +241,10 @@ describe('Top', () => {
                 items: bestEffortPodList,
             });
             const result = await topPodsFunc();
-            expect(result.length).to.equal(1);
-            expect(result[0].CPU).to.deep.equal({
-                CurrentUsage: 0.05,
-                LimitTotal: 0,
-                RequestTotal: 0,
-            });
-            expect(result[0].Memory).to.deep.equal({
-                CurrentUsage: BigInt('4005888'),
-                RequestTotal: 0,
-                LimitTotal: 0,
-            });
-            expect(result[0].Containers).to.deep.equal([
+            strictEqual(result.length, 1);
+            deepStrictEqual(result[0].CPU, new CurrentResourceUsage(0.05, 0, 0));
+            deepStrictEqual(result[0].Memory, new CurrentResourceUsage(BigInt('4005888'), 0, 0));
+            deepEqual(result[0].Containers, [
                 {
                     CPUUsage: {
                         CurrentUsage: 0.05,
@@ -287,29 +269,19 @@ describe('Top', () => {
                 items: podList,
             });
             const result = await topPodsFunc();
-            expect(result.length).to.equal(2);
-            expect(result[0].CPU).to.deep.equal({
-                CurrentUsage: 0,
-                LimitTotal: 0.1,
-                RequestTotal: 0.1,
-            });
-            expect(result[0].Memory).to.deep.equal({
-                CurrentUsage: 0,
-                RequestTotal: BigInt('104857600'),
-                LimitTotal: BigInt('104857600'),
-            });
-            expect(result[0].Containers).to.deep.equal([]);
-            expect(result[1].CPU).to.deep.equal({
-                CurrentUsage: 0,
-                LimitTotal: 2.1,
-                RequestTotal: 2.1,
-            });
-            expect(result[1].Memory).to.deep.equal({
-                CurrentUsage: 0,
-                LimitTotal: BigInt('209715200'),
-                RequestTotal: BigInt('157286400'),
-            });
-            expect(result[1].Containers).to.deep.equal([]);
+            strictEqual(result.length, 2);
+            deepStrictEqual(result[0].CPU, new CurrentResourceUsage(0, 0.1, 0.1));
+            deepStrictEqual(
+                result[0].Memory,
+                new CurrentResourceUsage(0, BigInt('104857600'), BigInt('104857600')),
+            );
+            deepStrictEqual(result[0].Containers, []);
+            deepStrictEqual(result[1].CPU, new CurrentResourceUsage(0, 2.1, 2.1));
+            deepStrictEqual(
+                result[1].Memory,
+                new CurrentResourceUsage(0, BigInt('157286400'), BigInt('209715200')),
+            );
+            deepStrictEqual(result[1].Containers, []);
             podMetrics.done();
             pods.done();
         });
@@ -320,7 +292,7 @@ describe('Top', () => {
                 items: [],
             });
             const result = await topPodsFunc();
-            expect(result.length).to.equal(0);
+            strictEqual(result.length, 0);
             podMetrics.done();
             pods.done();
         });
@@ -333,18 +305,13 @@ describe('Top', () => {
                 items: podList,
             });
             const result = await topPodsFunc();
-            expect(result.length).to.equal(2);
-            expect(result[0].CPU).to.deep.equal({
-                CurrentUsage: 0.05,
-                LimitTotal: 0.1,
-                RequestTotal: 0.1,
-            });
-            expect(result[0].Memory).to.deep.equal({
-                CurrentUsage: BigInt('4005888'),
-                RequestTotal: BigInt('104857600'),
-                LimitTotal: BigInt('104857600'),
-            });
-            expect(result[0].Containers).to.deep.equal([
+            strictEqual(result.length, 2);
+            deepStrictEqual(result[0].CPU, new CurrentResourceUsage(0.05, 0.1, 0.1));
+            deepStrictEqual(
+                result[0].Memory,
+                new CurrentResourceUsage(BigInt('4005888'), BigInt('104857600'), BigInt('104857600')),
+            );
+            deepEqual(result[0].Containers, [
                 {
                     CPUUsage: {
                         CurrentUsage: 0.05,
@@ -359,17 +326,12 @@ describe('Top', () => {
                     },
                 },
             ]);
-            expect(result[1].CPU).to.deep.equal({
-                CurrentUsage: 1.4,
-                LimitTotal: 2.1,
-                RequestTotal: 2.1,
-            });
-            expect(result[1].Memory).to.deep.equal({
-                CurrentUsage: BigInt('7192576'),
-                LimitTotal: BigInt('209715200'),
-                RequestTotal: BigInt('157286400'),
-            });
-            expect(result[1].Containers).to.deep.equal([
+            deepStrictEqual(result[1].CPU, new CurrentResourceUsage(1.4, 2.1, 2.1));
+            deepStrictEqual(
+                result[1].Memory,
+                new CurrentResourceUsage(BigInt('7192576'), BigInt('157286400'), BigInt('209715200')),
+            );
+            deepEqual(result[1].Containers, [
                 {
                     CPUUsage: {
                         CurrentUsage: 0,

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { deepStrictEqual, rejects, strictEqual } from 'node:assert';
 import nock from 'nock';
 import { PassThrough } from 'node:stream';
 import { KubeConfig } from './config.js';
@@ -65,8 +65,8 @@ describe('Watch', () => {
                 doneErr = err;
             },
         );
-        expect(doneCalled).to.equal(true);
-        expect(doneErr.toString()).to.equal('Error: Internal Server Error');
+        strictEqual(doneCalled, true);
+        strictEqual(doneErr.toString(), 'Error: Internal Server Error');
         s.done();
     });
 
@@ -148,18 +148,18 @@ describe('Watch', () => {
 
         await handledAllObjectsPromise;
 
-        expect(receivedTypes).to.deep.equal([obj1.type, obj2.type]);
-        expect(receivedObjects).to.deep.equal([obj1.object, obj2.object]);
+        deepStrictEqual(receivedTypes, [obj1.type, obj2.type]);
+        deepStrictEqual(receivedObjects, [obj1.object, obj2.object]);
 
-        expect(doneCalled).to.equal(0);
+        strictEqual(doneCalled, 0);
 
         const errIn = new Error('err');
         (response as IncomingMessage).socket.destroy(errIn);
 
         await donePromise;
 
-        expect(doneCalled).to.equal(1);
-        expect(doneErr).to.deep.equal(errIn);
+        strictEqual(doneCalled, 1);
+        deepStrictEqual(doneErr, errIn);
 
         s.done();
 
@@ -226,18 +226,18 @@ describe('Watch', () => {
 
         await handledAllObjectsPromise;
 
-        expect(receivedTypes).to.deep.equal([obj1.type]);
-        expect(receivedObjects).to.deep.equal([obj1.object]);
+        deepStrictEqual(receivedTypes, [obj1.type]);
+        deepStrictEqual(receivedObjects, [obj1.object]);
 
-        expect(doneErr.length).to.equal(0);
+        strictEqual(doneErr.length, 0);
 
         const errIn = new Error('err');
         (response as IncomingMessage).socket.destroy(errIn);
 
         await donePromise;
 
-        expect(doneErr.length).to.equal(1);
-        expect(doneErr[0]).to.deep.equal(errIn);
+        strictEqual(doneErr.length, 1);
+        deepStrictEqual(doneErr[0], errIn);
 
         s.done();
 
@@ -299,17 +299,16 @@ describe('Watch', () => {
 
         await handledAllObjectsPromise;
 
-        expect(receivedTypes).to.deep.equal([obj1.type]);
-        expect(receivedObjects).to.deep.equal([obj1.object]);
-
-        expect(doneErr.length).to.equal(0);
+        deepStrictEqual(receivedTypes, [obj1.type]);
+        deepStrictEqual(receivedObjects, [obj1.object]);
+        strictEqual(doneErr.length, 0);
 
         stream.end();
 
         await donePromise;
 
-        expect(doneErr.length).to.equal(1);
-        expect(doneErr[0]).to.equal(null);
+        strictEqual(doneErr.length, 1);
+        strictEqual(doneErr[0], null);
 
         s.done();
 
@@ -364,13 +363,13 @@ describe('Watch', () => {
 
         await donePromise;
 
-        expect(receivedTypes).to.deep.equal([obj.type]);
-        expect(receivedObjects).to.deep.equal([obj.object]);
+        deepStrictEqual(receivedTypes, [obj.type]);
+        deepStrictEqual(receivedObjects, [obj.object]);
 
         s.done();
     });
 
-    it('should throw on empty config', () => {
+    it('should throw on empty config', async () => {
         const kc = new KubeConfig();
         const watch = new Watch(kc);
 
@@ -380,6 +379,6 @@ describe('Watch', () => {
             () => {},
             () => {},
         );
-        expect(promise).to.be.rejected;
+        await rejects(promise);
     });
 });

--- a/src/yaml_test.ts
+++ b/src/yaml_test.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-
+import { deepStrictEqual, strictEqual } from 'node:assert';
 import { V1Namespace } from './api.js';
 import { dumpYaml, loadAllYaml, loadYaml } from './yaml.js';
 
@@ -8,9 +7,9 @@ describe('yaml', () => {
         const yaml = 'apiVersion: v1\n' + 'kind: Namespace\n' + 'metadata:\n' + '  name: some-namespace\n';
         const ns = loadYaml<V1Namespace>(yaml);
 
-        expect(ns.apiVersion).to.equal('v1');
-        expect(ns.kind).to.equal('Namespace');
-        expect(ns.metadata!.name).to.equal('some-namespace');
+        strictEqual(ns.apiVersion, 'v1');
+        strictEqual(ns.kind, 'Namespace');
+        strictEqual(ns.metadata!.name, 'some-namespace');
     });
     it('should load all safely', () => {
         const yaml =
@@ -26,12 +25,12 @@ describe('yaml', () => {
             '  namespace: some-ns\n';
         const objects = loadAllYaml(yaml);
 
-        expect(objects.length).to.equal(2);
-        expect(objects[0].kind).to.equal('Namespace');
-        expect(objects[1].kind).to.equal('Pod');
-        expect(objects[0].metadata.name).to.equal('some-namespace');
-        expect(objects[1].metadata.name).to.equal('some-pod');
-        expect(objects[1].metadata.namespace).to.equal('some-ns');
+        strictEqual(objects.length, 2);
+        strictEqual(objects[0].kind, 'Namespace');
+        strictEqual(objects[1].kind, 'Pod');
+        strictEqual(objects[0].metadata.name, 'some-namespace');
+        strictEqual(objects[1].metadata.name, 'some-pod');
+        strictEqual(objects[1].metadata.namespace, 'some-ns');
     });
     it('should round trip successfully', () => {
         const expected = {
@@ -41,6 +40,6 @@ describe('yaml', () => {
         };
         const yamlString = dumpYaml(expected);
         const actual = loadYaml(yamlString);
-        expect(actual).to.deep.equal(expected);
+        deepStrictEqual(actual, expected);
     });
 });


### PR DESCRIPTION
This commit replaces the uses of chai and chai-as-promised
throughout the codebase.

Fixes: https://github.com/kubernetes-client/javascript/issues/2165