### PR TITLE
examples: fix confusing patch example code

### DIFF
--- a/examples/patch-example.js
+++ b/examples/patch-example.js
@@ -25,9 +25,8 @@ try {
         },
         post: async (responseContext) => responseContext,
     });
-    let currentContext = kc.getCurrentContext();
-    let currentCluster = kc.getCluster(currentContext);
-    if (currentCluster === undefined || currentCluster === null) {
+    let currentCluster = kc.getCurrentCluster();
+    if (currentCluster === null) {
         throw new Error('Cluster is undefined');
     }
     let server = currentCluster.server;

--- a/examples/typescript/patch/patch-example.ts
+++ b/examples/typescript/patch/patch-example.ts
@@ -32,9 +32,8 @@ try {
         },
         post: async (responseContext: ResponseContext) => responseContext,
     });
-    const currentContext = kc.getCurrentContext();
-    const currentCluster = kc.getCluster(currentContext);
-    if (currentCluster === undefined || currentCluster === null) {
+    const currentCluster = kc.getCurrentCluster();
+    if (currentCluster === null) {
         throw new Error('Cluster is undefined');
     }
     const server = currentCluster.server;


### PR DESCRIPTION
This commit updates the patch examples to use `getCurrentCluster()`. The existing code relied on the current context having the same name as a cluster.

Refs: https://github.com/kubernetes-client/javascript/issues/2168