### PR TITLE
src: update for node-fetch v3 compatibility

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -168,7 +168,7 @@ export class KubeConfig implements SecurityAuthentication {
             headers,
             method: opts.method,
             timeout: opts.timeout,
-        };
+        } as RequestInit;
     }
 
     public async applyToHTTPSOptions(opts: https.RequestOptions | WebSocket.ClientOptions): Promise<void> {

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -284,13 +284,14 @@ describe('KubeConfig', () => {
             });
 
             strictEqual(requestInit.method, 'POST');
-            strictEqual(requestInit.timeout, 5);
-            deepEqual((requestInit.headers as Headers).raw(), {
-                Authorization: ['Basic Zm9vOmJhcg=='],
-                list: ['a', 'b'],
-                number: ['5'],
-                string: ['str'],
-            });
+            // timeout has been removed from the spec.
+            strictEqual((requestInit as any).timeout, 5);
+            const headers = requestInit.headers as Headers;
+            strictEqual(Array.from(headers).length, 4);
+            strictEqual(headers.get('Authorization'), 'Basic Zm9vOmJhcg==');
+            strictEqual(headers.get('list'), 'a, b');
+            strictEqual(headers.get('number'), '5');
+            strictEqual(headers.get('string'), 'str');
             assertRequestAgentsEqual(requestInit.agent as Agent, expectedAgent);
         });
     });

--- a/src/log.ts
+++ b/src/log.ts
@@ -140,7 +140,7 @@ export class Log {
             const status = response.status;
             if (status === 200) {
                 // TODO: the follow search param still has the stream close prematurely based on my testing
-                response.body.pipe(stream);
+                response.body!.pipe(stream);
             } else if (status === 500) {
                 const v1status = response.body as V1Status;
                 const v1code = v1status.code;

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -154,7 +154,7 @@ describe('Watch', () => {
         strictEqual(doneCalled, 0);
 
         const errIn = new Error('err');
-        (response as IncomingMessage).socket.destroy(errIn);
+        (response as IncomingMessage).destroy(errIn);
 
         await donePromise;
 
@@ -232,7 +232,7 @@ describe('Watch', () => {
         strictEqual(doneErr.length, 0);
 
         const errIn = new Error('err');
-        (response as IncomingMessage).socket.destroy(errIn);
+        (response as IncomingMessage).destroy(errIn);
 
         await donePromise;
 


### PR DESCRIPTION
While the code generator still needs to be updated to use node-fetch v3, these changes make the library compatible with it. Since node-fetch v3 is more up to date, I think it makes sense to try to be compatible with it.

Tested with v3 by applying these changes on top of #2146. This seems to work with node-fetch v2 and v3.