### PR TITLE
ci: update permissions for CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,11 @@ on:
     schedule:
         - cron: '35 14 * * 3'
 
+permissions:
+    actions: read
+    contents: read
+    security-events: write
+
 jobs:
     analyze:
         name: Analyze


### PR DESCRIPTION
This commit updates the CodeQL scanning job's permissions as recommended in several places.

Refs: https://github.com/octokit/types.ts/blob/bb399b2f7126e587f2d6ff590bf3cffb9560c542/.github/workflows/codeql.yml#L11-L14
Refs: https://github.com/github/codeql/issues/8843
Fixes: https://github.com/kubernetes-client/javascript/issues/2193