### PR TITLE
docs: correct directory and set entryPointStrategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test-transpiled": "mocha --no-config dist",
         "prepare": "npm run build && husky",
         "prepack": "npm run build",
-        "docs": "typedoc src/gen/api"
+        "docs": "typedoc src/gen/apis"
     },
     "c8": {
         "include": [

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,3 +1,4 @@
 {
-  "out": "docs"
+    "out": "docs",
+    "entryPointStrategy": "expand"
 }


### PR DESCRIPTION
The directory where to generate the docs from was wrong, I'm not sure
when this changed but probably during the move from release-0.x to
release-1.x.

Also the `entryPointStrategy` needed to be set so that we are able to
include these files to generate the docs even if our ts-config doesn't
include them.
This was the default behavior a couple of releases of typedoc ago but
was changed.

Closes #2209
