### PR TITLE
Offer both ESM & CommonJS versions of the Javascript client

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,29 @@
         "url": "https://github.com/kubernetes-client/javascript.git"
     },
     "files": [
-        "dist/**/*.ts",
-        "dist/**/*.js",
-        "dist/**/*.map"
+        "dist/{mjs,cjs}/*.js",
+        "dist/{mjs,cjs}/*.map",
+        "dist/{mjs,cjs}/*.ts",
+        "dist/{mjs,cjs}/gen/**/*.js",
+        "dist/{mjs,cjs}/gen/**/*.map",
+        "dist/{mjs,cjs}/gen/**/*.ts",
+        "dist/{mjs,cjs}/gen/*.js",
+        "dist/{mjs,cjs}/gen/*.map",
+        "dist/{mjs,cjs}/gen/*.ts"
     ],
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
+    "main": "dist/mjs/index.js",
+    "types": "dist/mjs/index.d.ts",
+    "exports": {
+        ".": {
+            "require": "./dist/cjs/index.js",
+            "import": "./dist/esm/index.js"
+        }
+    },
     "scripts": {
         "format": "prettier --log-level error --write \"./src/**/*.ts\"",
         "lint": "eslint \".\" && prettier --check \"./src/**/*.ts\"",
         "clean": "rm -Rf node_modules/ dist/",
-        "build": "tsc",
+        "build": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
         "build-with-tests": "tsc --project tsconfig-with-tests.json && cp 'src/test/echo space.js' dist/test",
         "generate": "./generate-client.sh",
         "watch": "tsc --watch",

--- a/src/integration_test.ts
+++ b/src/integration_test.ts
@@ -40,7 +40,7 @@ describe('FullRequest', () => {
 
             const list = await k8sApi.listNamespacedPod({ namespace: 'default' });
 
-            return deepEqual(list, result);
+            deepEqual(list, result);
         });
     });
 });

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "outDir": "dist/cjs"
+    },
+    "exclude": ["node_modules", "src/*_test.ts", "src/test", "dist"],
+    "extends": "./tsconfig.json",
+    "include": ["*.ts", "src/**/*"]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "outDir": "dist/mjs"
+    },
+    "exclude": ["node_modules", "src/*_test.ts", "src/test", "dist"],
+    "extends": "./tsconfig.json",
+    "include": ["*.ts", "src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,16 @@
         // "declarationMap": true
     },
     "exclude": ["node_modules", "src/*_test.ts", "src/test", "dist"],
-    "include": ["*.ts", "src/**/*"]
+    "include": ["*.ts", "src/**/*"],
+    "reference": [
+        {
+            "path": "tsconfig.cjs.json"
+        },
+        {
+            "path": "tsconfig.mjs.json"
+        },
+        {
+            "path": "tsconfig-with-tests.json"
+        }
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
     "compilerOptions": {
-        "module": "nodenext",
-        "noImplicitAny": false,
-        "target": "es2019",
-        "lib": ["es2023"],
-        "moduleResolution": "nodenext",
-        "removeComments": false,
-        "sourceMap": true,
-        "noLib": false,
         "declaration": true,
-        "outDir": "dist",
-        "rootDir": "src",
-        "strict": true,
+        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
+        "lib": ["es2023"],
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "noImplicitAny": false,
+        "noLib": false,
+        "outDir": "dist",
+        "removeComments": false,
+        "rootDir": "src",
         "skipLibCheck": true,
-        "esModuleInterop": true
+        "sourceMap": true,
+        "strict": true,
+        "target": "es2019"
         // enable this in the future
         // "declarationMap": true
     },


### PR DESCRIPTION
## Summary

This pull request introduces key improvements to the @kubernetes/client-node package, focusing on enhancing module compatibility, maintainability, and test code clarity. The changes have been distributed across three commits to facilitate easier review.
## Changes

* Build Enhancement:
        Added support for the CommonJS module format in the bundled package. This change includes the creation of separate tsconfig.cjs.json and tsconfig.esm.json files to manage different module outputs.

*   Chore:
        Sorted keys in tsconfig.json for improved readability and maintainability.

*    Test Improvement:
        Removed a needless return statement from src/integration_test.ts as the return type of deepEqual is void. This change clarifies the test logic and aligns with best practices for writing tests.

## Reason for Change

The primary motivation for adding CommonJS support is to optimize the performance of applications that still rely on jest. Without this change, these applications would need to transpile the entire package, leading to slower build times and reduced efficiency. Additionally, cleaning up the test code enhances code readability and maintainability.
Impact

These changes should improve the flexibility and performance of the package distribution, making it easier to integrate with a wider range of environments and frameworks, while also ensuring that the test code is clean and easy to understand.

## Review Notes

The changes have been distributed across three separate commits, making it easier for reviewers to focus on specific aspects of the update and provide targeted feedback.