### PR TITLE
include source maps in npm pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,9 @@
         "url": "https://github.com/kubernetes-client/javascript.git"
     },
     "files": [
-        "dist/*.ts",
-        "dist/*.js",
-        "dist/gen/*.ts",
-        "dist/gen/*.js",
-        "dist/gen/**/*.ts",
-        "dist/gen/**/*.js",
-        "README.md"
+        "dist/**/*.ts",
+        "dist/**/*.js",
+        "dist/**/*.map"
     ],
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
This commit includes the generated source maps in the artifact published to npm. This commit also simplifies the patterns used to match files. Some files, such as README are always included, so it has been removed here.

Refs: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files
Fixes: https://github.com/kubernetes-client/javascript/issues/2249