### PR TITLE
bump jsonpath-plus minimum version to 10.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "hpagent": "^1.2.0",
                 "isomorphic-ws": "^5.0.0",
                 "js-yaml": "^4.1.0",
-                "jsonpath-plus": "^10.2.0",
+                "jsonpath-plus": "^10.3.0",
                 "node-fetch": "^2.6.9",
                 "openid-client": "^6.1.3",
                 "rfc4648": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "hpagent": "^1.2.0",
         "isomorphic-ws": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^10.2.0",
+        "jsonpath-plus": "^10.3.0",
         "node-fetch": "^2.6.9",
         "openid-client": "^6.1.3",
         "rfc4648": "^1.3.0",


### PR DESCRIPTION
[Resolves vulnerability reported by Snyk](https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-8719585).

For any new installations this should pick up `10.3.0`, but this change ensures there's no risk of installing any problematic versions.

- [x] `npm test` passes
- [x] `npm run generate` yields no errors