### PR TITLE
improve coverage for top.ts by covering topNodes.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,13 @@ export default tseslint.config(
             '@typescript-eslint/no-empty-object-type': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    args: 'none',
+                    destructuredArrayIgnorePattern: '^_',
+                },
+            ],
         },
     },
 );

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,9 @@ import { CoreV1Api, V1Container, V1Pod } from './gen/index.js';
 
 export async function podsForNode(api: CoreV1Api, nodeName: string): Promise<V1Pod[]> {
     const allPods = await api.listPodForAllNamespaces();
+    if (!allPods.items) {
+        return [];
+    }
     return allPods.items.filter((pod: V1Pod) => pod.spec!.nodeName === nodeName);
 }
 


### PR DESCRIPTION
Another day, another Github Copilot authored improvement to test coverage.

I'll give Copilot 50% credit here, it copied the topPods test a little too closely and failed to figure out that there were some extra calls that needed to be mocked.

Still, faster than me doing it all myself by at least 50%.

Also added eslint rule to ignore `_` in array destructuring, I think that is a good style change, but open to other opinions.