### PR TITLE
test: handle process.env in config_test.ts

### DIFF
--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1613,6 +1613,19 @@ describe('KubeConfig', () => {
     });
 
     describe('BufferOrFile', () => {
+        let originalEnv;
+
+        before(() => {
+            // The code being tested here references process.env and can fail
+            // if run on a machine with certain environment variable settings.
+            originalEnv = process.env;
+            process.env = {};
+        });
+
+        after(() => {
+            process.env = originalEnv;
+        });
+
         it('should load from root if present', () => {
             const data = 'some data for file';
             const arg: any = {


### PR DESCRIPTION
The tests in #2288 can fail depending on the environment variables on the system. This commit takes the environment out of the equation.

Refs: https://github.com/kubernetes-client/javascript/pull/2288