### PR TITLE
docs: generate docs for the whole `gen` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test-transpiled": "mocha --no-config dist",
         "prepare": "npm run build && husky",
         "prepack": "npm run build",
-        "docs": "typedoc src/gen/apis"
+        "docs": "typedoc src/gen"
     },
     "c8": {
         "include": [


### PR DESCRIPTION
Closes #2218

There was an indeed an error in which files we include to generate the docs.

<img width="1624" alt="Screenshot 2025-03-08 at 12 46 56" src="https://github.com/user-attachments/assets/2a61389c-410d-49d0-95f7-5cb1a34bca8f" />
