### PR TITLE
update HeaderMiddleware types, export PatchStrategy with Integration Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,6 @@ jobs:
             - run: npm run lint
             - run: npm audit --audit-level=critical
             - run: npm run build-with-tests && npm run test-transpiled
+            - name: Create k8s Kind Cluster
+              uses: helm/kind-action@v1
+            - run: npm run integration-test

--- a/examples/typescript/patch/patch-example.ts
+++ b/examples/typescript/patch/patch-example.ts
@@ -1,4 +1,5 @@
-import { CoreV1Api, KubeConfig, setHeaderOptions, JsonPatch } from '@kubernetes/client-node';
+import { CoreV1Api, KubeConfig, setHeaderOptions } from '@kubernetes/client-node';
+import { PatchStrategy } from '@kubernetes/client-node/patch';
 
 const kc = new KubeConfig();
 kc.loadFromDefault();
@@ -28,7 +29,7 @@ try {
             namespace: 'default',
             body: patch,
         },
-        setHeaderOptions('Content-Type', JsonPatch),
+        setHeaderOptions('Content-Type', PatchStrategy.JsonPatch),
     );
 
     console.log('Patched.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
                 "prettier": "^3.0.0",
                 "pretty-quick": "^4.0.0",
                 "ts-mockito": "^2.3.1",
-                "tsx": "^4.19.1",
+                "ts-node": "^10.9.2",
+                "tsx": "^4.19.3",
                 "typedoc": "^0.27.1",
                 "typescript": "~5.8.2",
                 "typescript-eslint": "^8.26.0"
@@ -56,6 +57,30 @@
             "dev": true,
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -927,6 +952,34 @@
             "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
             "dev": true
         },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1263,6 +1316,19 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/agent-base": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -1333,6 +1399,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -1566,6 +1639,13 @@
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1628,6 +1708,16 @@
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/dunder-proto": {
@@ -2759,6 +2849,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/markdown-it": {
             "version": "14.1.0",
@@ -3900,6 +3997,50 @@
                 "lodash": "^4.17.5"
             }
         },
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4043,6 +4184,13 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.2.0",
@@ -4221,6 +4369,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4240,6 +4398,27 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.1.tgz",
             "integrity": "sha512-W+a0/JpU28AqH4IKtwUPcEUnUyXMDLALcn5/JLczGGT9fHE2sIby/xP/oQnx3nxkForzgzPy201RAKcB4xPAFQ==",
             "dev": true
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "dependencies": {
+                "@jridgewell/trace-mapping": {
+                    "version": "0.3.9",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+                    "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/resolve-uri": "^3.0.3",
+                        "@jridgewell/sourcemap-codec": "^1.4.10"
+                    }
+                }
+            }
         },
         "@esbuild/aix-ppc64": {
             "version": "0.25.0",
@@ -4715,6 +4894,30 @@
             "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
             "dev": true
         },
+        "@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true
+        },
         "@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -4946,6 +5149,15 @@
             "dev": true,
             "requires": {}
         },
+        "acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.11.0"
+            }
+        },
         "agent-base": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -4991,6 +5203,12 @@
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
             }
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
@@ -5157,6 +5375,12 @@
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
         "cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5202,6 +5426,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true
         },
         "dunder-proto": {
             "version": "1.0.1",
@@ -5981,6 +6211,12 @@
                 "semver": "^7.5.3"
             }
         },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
         "markdown-it": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -6744,6 +6980,27 @@
                 "lodash": "^4.17.5"
             }
         },
+        "ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            }
+        },
         "tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6839,6 +7096,12 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "9.2.0",
@@ -6953,6 +7216,12 @@
                     "dev": true
                 }
             }
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "watch": "tsc --watch",
         "test": "c8 mocha",
         "test-transpiled": "mocha --no-config dist",
+        "integration-test": "tsx src/test/integration/index.ts",
         "prepare": "npm run build && husky",
         "prepack": "npm run build",
         "docs": "typedoc src/gen"

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export * from './metrics.js';
 export * from './object.js';
 export * from './health.js';
 export * from './middleware.js';
+export * from './patch.js';
 export { type ConfigOptions, type User, type Cluster, type Context } from './config_types.js';
 
 // Export FetchError so that instanceof checks in user code will definitely use the same instance

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ import type {
 } from './gen/index.js';
 import { of } from './gen/rxjsStub.js';
 
-function setHeaderMiddleware(key: string, value: string): ObservableMiddleware {
+export function setHeaderMiddleware(key: string, value: string): ObservableMiddleware {
     return {
         pre: (request: RequestContext) => {
             request.setHeaderParam(key, value);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,27 +1,29 @@
-import type { RequestContext, ResponseContext, ConfigurationOptions, Middleware } from './gen/index.js';
-import { PromiseMiddleware } from './gen/middleware.js';
+import type {
+    RequestContext,
+    ResponseContext,
+    ConfigurationOptions,
+    ObservableMiddleware,
+} from './gen/index.js';
+import { of } from './gen/rxjsStub.js';
 
-// setHeaderMiddleware returns Middleware[] that sets a header value
-export function setHeaderMiddleware(key: string, value: string): Middleware[] {
-    return [
-        {
-            pre: async (c: RequestContext) => {
-                c.setHeaderParam(key, value);
-                return c;
-            },
-            post: async (c: ResponseContext) => {
-                return c;
-            },
+function setHeaderMiddleware(key: string, value: string): ObservableMiddleware {
+    return {
+        pre: (request: RequestContext) => {
+            request.setHeaderParam(key, value);
+            return of(request);
         },
-    ];
+        post: (response: ResponseContext) => {
+            return of(response);
+        },
+    };
 }
 
 // Returns ConfigurationOptions that set a header
 export function setHeaderOptions(
     key: string,
     value: string,
-    opt?: ConfigurationOptions<PromiseMiddleware>,
-): ConfigurationOptions<PromiseMiddleware> {
+    opt?: ConfigurationOptions<ObservableMiddleware>,
+): ConfigurationOptions<ObservableMiddleware> {
     const newMiddlware = setHeaderMiddleware(key, value);
     const existingMiddlware = opt?.middleware || [];
     return {

--- a/src/test/integration/index.ts
+++ b/src/test/integration/index.ts
@@ -1,4 +1,4 @@
-import patchNamespace from './patchNamespace';
+import patchNamespace from './patchNamespace.js';
 
 console.log('Integration testing');
 

--- a/src/test/integration/index.ts
+++ b/src/test/integration/index.ts
@@ -1,0 +1,5 @@
+import patchNamespace from './patchNamespace';
+
+console.log('Integration testing');
+
+patchNamespace();

--- a/src/test/integration/patchNamespace.ts
+++ b/src/test/integration/patchNamespace.ts
@@ -1,5 +1,5 @@
 import assert, { deepEqual } from 'node:assert';
-import { PatchStrategy, CoreV1Api, KubeConfig, setHeaderOptions, V1Namespace } from '../../index';
+import { PatchStrategy, CoreV1Api, KubeConfig, setHeaderOptions, V1Namespace } from '../../index.js';
 
 export default async function patchNamespace() {
     const kc = new KubeConfig();

--- a/src/test/integration/patchNamespace.ts
+++ b/src/test/integration/patchNamespace.ts
@@ -1,0 +1,47 @@
+import assert, { deepEqual } from 'node:assert';
+import { PatchStrategy, CoreV1Api, KubeConfig, setHeaderOptions, V1Namespace } from '../../index';
+
+export default async function patchNamespace() {
+    const kc = new KubeConfig();
+    kc.loadFromDefault();
+
+    const coreV1Client = kc.makeApiClient(CoreV1Api);
+    let newNS = new V1Namespace();
+    const testNSName = 'integration-test-patch-ns';
+    newNS.metadata = {
+        name: testNSName,
+        labels: {
+            initialLabel: 'initialValue',
+        },
+    };
+    console.log(`Creating namespace ${testNSName}`);
+    await coreV1Client.createNamespace({ body: newNS });
+    newNS = await coreV1Client.readNamespace({ name: testNSName });
+    assert(newNS.metadata?.name === testNSName);
+    deepEqual(newNS.metadata?.labels?.initialLabel, 'initialValue');
+    console.log('Namespace created with initial label.');
+
+    const patch = [
+        {
+            op: 'replace',
+            path: '/metadata/labels',
+            value: {
+                foo: 'bar',
+            },
+        },
+    ];
+
+    console.log(`Patching namespace ${testNSName} to replace labels`);
+    await coreV1Client.patchNamespace(
+        {
+            name: testNSName,
+            body: patch,
+        },
+        setHeaderOptions('Content-Type', PatchStrategy.JsonPatch),
+    );
+
+    const patchedNS = await coreV1Client.readNamespace({ name: testNSName });
+    deepEqual(patchedNS.metadata?.labels?.foo, 'bar');
+    deepEqual(patchedNS.metadata?.labels?.initialLabel, undefined);
+    console.log('Namespace patched with new label.');
+}


### PR DESCRIPTION
- Update `setHeaderMiddleware` and `setHeaderOptions` to ObservableMiddleware type to match our exported type s

- Export `PatchStrategy` from the index

- Add `integration-test` script

- Add kind cluster integration test that validates these changes

ref https://github.com/kubernetes-client/javascript/issues/2160

It would be great to execute the examples _as integration tests_ against the kind cluster in the future to ensure examples must remain functional