### PR TITLE
Add 1.1.x to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Generally speaking newer clients will work with older Kubernetes, but compatabil
 | 0.21.x         | -              | +    | +    | ✓    | x    | x    |
 | 0.22.x         | -              | +    | +    | +    | ✓    | x    |
 | 1.0.x          | -              | +    | +    | +    | +    | ✓    |
+| 1.1.x          | -              | +    | +    | +    | +    | ✓    |
 
 Key:
 


### PR DESCRIPTION
To stay consistent with the client compatibility table, i added the 1.1.x minor version release to the README

Since we are following semver, we won't have 1 minor version per k8s version anymore