### PR TITLE
fix: apply http agent if needed

### DIFF
--- a/src/cache_test.ts
+++ b/src/cache_test.ts
@@ -11,7 +11,7 @@ import { ListPromise } from './informer.js';
 import nock from 'nock';
 import { Watch } from './watch.js';
 
-const server = 'http://foo.company.com';
+const server = 'https://foo.company.com';
 
 const fakeConfig: {
     clusters: Cluster[];

--- a/src/config.ts
+++ b/src/config.ts
@@ -545,8 +545,10 @@ export class KubeConfig implements SecurityAuthentication {
             } else {
                 throw new Error('Unsupported proxy type');
             }
-        } else if (cluster?.server?.startsWith('http:')) {
+        } else if (cluster?.server?.startsWith('http:') && cluster.skipTLSVerify) {
             agent = new http.Agent(agentOptions);
+        } else if (cluster?.server?.startsWith('http:') && !cluster.skipTLSVerify) {
+            throw new Error('HTTP protocol is not allowed when skipTLSVerify is not set or false');
         } else {
             agent = new https.Agent(agentOptions);
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -545,7 +545,7 @@ export class KubeConfig implements SecurityAuthentication {
             } else {
                 throw new Error('Unsupported proxy type');
             }
-        } else if (cluster && cluster.server && cluster.server.startsWith('http:')) {
+        } else if (cluster?.server?.startsWith('http:')) {
             agent = new http.Agent(agentOptions);
         } else {
             agent = new https.Agent(agentOptions);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import https from 'node:https';
+import http from 'node:http';
 import yaml from 'js-yaml';
 import net from 'node:net';
 import path from 'node:path';
@@ -544,6 +545,8 @@ export class KubeConfig implements SecurityAuthentication {
             } else {
                 throw new Error('Unsupported proxy type');
             }
+        } else if (cluster && cluster.server && cluster.server.startsWith('http:')) {
+            agent = new http.Agent(agentOptions);
         } else {
             agent = new https.Agent(agentOptions);
         }

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1,5 +1,12 @@
 import { after, before, beforeEach, describe, it, mock } from 'node:test';
-import { deepEqual, deepStrictEqual, notStrictEqual, rejects, strictEqual, throws } from 'node:assert';
+import assert, {
+    deepEqual,
+    deepStrictEqual,
+    notStrictEqual,
+    rejects,
+    strictEqual,
+    throws,
+} from 'node:assert';
 import child_process from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import https from 'node:https';
@@ -461,10 +468,20 @@ describe('KubeConfig', () => {
 
             strictEqual(rc.getAgent() instanceof http.Agent, true);
         });
-        it('should apply https agent if cluster.server starts with https and no proxy-url is provided', async () => {
+        it('should throw an error if cluster.server starts with http, no proxy-url is provided and insecure-skip-tls-verify is not set', async () => {
             const kc = new KubeConfig();
             kc.loadFromFile(kcProxyUrl);
             kc.setCurrentContext('contextF');
+
+            const testServerName = 'http://example.com';
+            const rc = new RequestContext(testServerName, HttpMethod.GET);
+
+            await assert.rejects(kc.applySecurityAuthentication(rc), Error);
+        });
+        it('should apply https agent if cluster.server starts with https and no proxy-url is provided', async () => {
+            const kc = new KubeConfig();
+            kc.loadFromFile(kcProxyUrl);
+            kc.setCurrentContext('contextG');
 
             const testServerName = 'https://example.com';
             const rc = new RequestContext(testServerName, HttpMethod.GET);

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -299,7 +299,7 @@ describe('KubeConfig', () => {
         });
     });
 
-    describe.only('applyHTTPSOptions', () => {
+    describe('applyHTTPSOptions', () => {
         it('should apply tls-server-name to https.RequestOptions', async () => {
             const kc = new KubeConfig();
             kc.loadFromFile(kcTlsServerNameFileName);

--- a/src/watch_test.ts
+++ b/src/watch_test.ts
@@ -7,7 +7,7 @@ import { Cluster, Context, User } from './config_types.js';
 import { Watch } from './watch.js';
 import { IncomingMessage } from 'node:http';
 
-const server = 'http://foo.company.com';
+const server = 'https://foo.company.com';
 
 const fakeConfig: {
     clusters: Cluster[];

--- a/testdata/kubeconfig-proxy-url.yaml
+++ b/testdata/kubeconfig-proxy-url.yaml
@@ -20,6 +20,15 @@ clusters:
           server: htto://exampleerror.com
           proxy-url: http://example:8080
       name: clusterD
+    - cluster:
+          certificate-authority-data: Q0FEQVRA
+          server: http://exampleerror.com
+          insecure-skip-tls-verify: true
+      name: clusterE
+    - cluster:
+          certificate-authority-data: Q0FEQVRA
+          server: http://exampleerror.com
+      name: clusterF
 
 contexts:
     - context:
@@ -38,6 +47,14 @@ contexts:
           cluster: clusterD
           user: userD
       name: contextD
+    - context:
+          cluster: clusterE
+          user: userE
+      name: contextE
+    - context:
+          cluster: clusterF
+          user: userF
+      name: contextF
 
 current-context: contextA
 kind: Config
@@ -56,6 +73,14 @@ users:
           client-certificate-data: XVNFUl9DQURBVEE=
           client-key-data: XVNFUl9DS0RBVEE=
     - name: userD
+      user:
+          client-certificate-data: XVNFUl9DQURBVEE=
+          client-key-data: XVNFUl9DS0RBVEE=
+    - name: userE
+      user:
+          client-certificate-data: XVNFUl9DQURBVEE=
+          client-key-data: XVNFUl9DS0RBVEE=
+    - name: userF
       user:
           client-certificate-data: XVNFUl9DQURBVEE=
           client-key-data: XVNFUl9DS0RBVEE=


### PR DESCRIPTION
This applies an http agent if needed.
I'm not entirely sure about the security implications of this, but I guess it should be not a problem though.

Fixes #2348
