### PR TITLE
Reintroduce timeout and keep-alive for watch requests to match client-go

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -41,6 +41,7 @@ export class Watch {
         const controller = new AbortController();
         requestInit.signal = controller.signal as AbortSignal;
         requestInit.method = 'GET';
+        requestInit.timeout = 30000;
 
         let doneCalled: boolean = false;
         const doneCallOnce = (err: any) => {
@@ -53,6 +54,12 @@ export class Watch {
 
         try {
             const response = await fetch(watchURL, requestInit);
+
+            if (requestInit.agent && typeof requestInit.agent === 'object') {
+                for (const socket of Object.values(requestInit.agent.sockets).flat()) {
+                    socket?.setKeepAlive(true, 30000);
+                }
+            }
 
             if (response.status === 200) {
                 const body = response.body!;


### PR DESCRIPTION
Thanks to @Alabate for opening the initial PR with this fix: https://github.com/kubernetes-client/javascript/pull/2131

This PR includes Alabate's fix + unit test coverage. Below is the original PR description copied here for reference:

---

This will send keep-alive probes to the server every 30 seconds. These features were present prior to the 1.0 but were inadvertently removed.

Fixes https://github.com/kubernetes-client/javascript/issues/2127

Previous relevant issues:

- Initial issue: https://github.com/kubernetes-client/javascript/issues/559
  - PR: https://github.com/kubernetes-client/javascript/pull/630
- Improvement: https://github.com/kubernetes-client/javascript/issues/632
  - PR: https://github.com/kubernetes-client/javascript/pull/635

## Implementation details
Setting `requestInit.timeout = 30000` is equivalent to `socket.setTimeout(30000)` as you can [see in the sources](https://github.com/nodejs/node/blob/main/lib/_http_agent.js#L527).

One of the solution suggested in https://github.com/kubernetes-client/javascript/issues/2127 was to use the keepAlive of the `http.Agent`. But [as documented here](https://nodejs.org/api/http.html#new-agentoptions), that's just a boolean that instruct the agent that we want sockets to be re-used. We want to send packets at a fixed rate to know when a connection is broken. This can be done with the [socket.setKeepAlive() method](https://nodejs.org/api/net.html#socketsetkeepaliveenable-initialdelay), but to use it, we need to access the socket object.

I managed to access the socket and call `setKeepAlive()`, but only after the `await fetch()`, when the response is already arriving. That's the only way I found to access the socket. The Agent create the socket, but [there is no event](https://nodejs.org/api/http.html#class-httpagent) to know when a socket created, you can just access them by list like I did. There is a [socket event on the request object](https://nodejs.org/api/http.html#event-socket), but `node-fetch` abstract it away, and I couldn't find a clean way to access it (https://github.com/node-fetch/node-fetch/discussions/1720 that request this feature).

The only way I've found to get the socket before the request was by monkey-patching the `agent.createConnection()`, but I think this solution is worse.

```ts
const _createConnection = agent.createConnection;
agent.createConnection = function (...args) {
  const socket = _createConnection.apply(agent, args);
  socket.setTimeout(3000);
  socket.setKeepAlive(true, 3000);
  return socket;
}