### PR TITLE
Fix patch-example.js content type import

### DIFF
--- a/examples/patch-example.js
+++ b/examples/patch-example.js
@@ -20,7 +20,7 @@ try {
 
     await k8sApi.patchNamespacedPod(
         { name: res?.items?.[0]?.metadata?.name ?? '', namespace, body: patch },
-        k8s.setHeaderOptions('Content-Type', k8s.JsonPatch),
+        k8s.setHeaderOptions('Content-Type', k8s.PatchStrategy.JsonPatch),
     );
 
     console.log('Patched.');


### PR DESCRIPTION
The import of `JsonPatch` is incorrect in the `patch-example.js`, this PR is here to fix it.