### PR TITLE
watch: prevent done callback from being called twice on connection loss

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -46,8 +46,8 @@ export class Watch {
         let doneCalled: boolean = false;
         const doneCallOnce = (err: any) => {
             if (!doneCalled) {
-                controller.abort();
                 doneCalled = true;
+                controller.abort();
                 done(err);
             }
         };


### PR DESCRIPTION
Avoids multiple invocations of the done callback when a watch connection is closed unexpectedly (e.g., a premature socket close). The fix sets `doneCalled = true` before calling `controller.abort()`, to ensure that any `AbortError` triggered by aborting does not result in another call to the done callback.

A regression test is included to simulate an abrupt connection termination. It uses a real HTTP server that flushes headers and then destroys the connection immediately. This reliably triggers the combination of `AbortError` and "Premature close" needed to reproduce the issue.

Refs: https://github.com/kubernetes-client/javascript/issues/2387