### PR TITLE
ci: test on Node v24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node: ['23', '22', '20', '18']
+                node: ['24', '23', '22', '20', '18']
         name: Node ${{ matrix.node }} validation
         steps:
             - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Node v24 was released today. This commit adds it to the CI matrix.