### PR TITLE
chore: readd ws as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
                 "rfc4648": "^1.3.0",
                 "socks-proxy-agent": "^8.0.4",
                 "stream-buffers": "^3.0.2",
-                "tar-fs": "^3.0.8"
+                "tar-fs": "^3.0.8",
+                "ws": "^8.18.2"
             },
             "devDependencies": {
                 "@eslint/js": "^9.18.0",
@@ -4742,11 +4743,10 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.18.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-            "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+            "version": "8.18.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+            "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
         "rfc4648": "^1.3.0",
         "socks-proxy-agent": "^8.0.4",
         "stream-buffers": "^3.0.2",
-        "tar-fs": "^3.0.8"
+        "tar-fs": "^3.0.8",
+        "ws": "^8.18.2"
     },
     "devDependencies": {
         "@eslint/js": "^9.18.0",


### PR DESCRIPTION
It seems like people having issues due to the removal of ws https://github.com/kubernetes-client/javascript/commit/b727c7be7fc7c7a8cb5663d6d621d92027d47fc1\#r156475449

It would be good if there would be another way than to reintroduce the dependency but I don't really know how and at the same time I don't think it's good to have every consumer install ws separately.