### PR TITLE
fix: readd AbortError export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,5 @@ export * from './middleware.js';
 export * from './patch.js';
 export { type ConfigOptions, type User, type Cluster, type Context } from './config_types.js';
 
-// Export FetchError so that instanceof checks in user code will definitely use the same instance
-export { FetchError } from 'node-fetch';
+// Export AbortError and FetchError so that instanceof checks in user code will definitely use the same instances
+export { AbortError, FetchError } from 'node-fetch';


### PR DESCRIPTION
This was removed in https://github.com/kubernetes-client/javascript/pull/2062

@cjihrig 