### PR TITLE
test: refactor several watch tests to not use nock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "eslint-plugin-erasable-syntax-only": "^0.3.0",
                 "husky": "^9.0.6",
                 "mock-fs": "^5.2.0",
-                "nock": "^13.2.9",
+                "nock": "^14.0.5",
                 "prettier": "^3.0.0",
                 "pretty-quick": "^4.0.0",
                 "ts-mockito": "^2.3.1",
@@ -828,6 +828,24 @@
                 "jsep": "^0.4.0||^1.0.0"
             }
         },
+        "node_modules/@mswjs/interceptors": {
+            "version": "0.38.7",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.7.tgz",
+            "integrity": "sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@open-draft/deferred-promise": "^2.2.0",
+                "@open-draft/logger": "^0.3.0",
+                "@open-draft/until": "^2.0.0",
+                "is-node-process": "^1.2.0",
+                "outvariant": "^1.4.3",
+                "strict-event-emitter": "^0.5.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -865,6 +883,31 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@open-draft/deferred-promise": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+            "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@open-draft/logger": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+            "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-node-process": "^1.2.0",
+                "outvariant": "^1.4.0"
+            }
+        },
+        "node_modules/@open-draft/until": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+            "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -2534,6 +2577,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-node-process": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+            "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2920,18 +2970,18 @@
             "license": "MIT"
         },
         "node_modules/nock": {
-            "version": "13.5.6",
-            "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-            "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+            "version": "14.0.5",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.5.tgz",
+            "integrity": "sha512-R49fALR9caB6vxuSWUIaK2eBYeTloZQUFBZ4rHO+TbhMGQHtwnhdqKLYki+o+8qMgLvoBYWrp/2KzGPhxL4S6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.1.0",
+                "@mswjs/interceptors": "^0.38.7",
                 "json-stringify-safe": "^5.0.1",
                 "propagate": "^2.0.0"
             },
             "engines": {
-                "node": ">= 10.13"
+                "node": ">=18.20.0 <20 || >=20.12.1"
             }
         },
         "node_modules/node-fetch": {
@@ -3002,6 +3052,13 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/outvariant": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+            "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
@@ -3442,6 +3499,13 @@
             "optionalDependencies": {
                 "bare-events": "^2.2.0"
             }
+        },
+        "node_modules/strict-event-emitter": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+            "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "eslint-plugin-erasable-syntax-only": "^0.3.0",
         "husky": "^9.0.6",
         "mock-fs": "^5.2.0",
-        "nock": "^13.2.9",
+        "nock": "^14.0.5",
         "prettier": "^3.0.0",
         "pretty-quick": "^4.0.0",
         "ts-mockito": "^2.3.1",


### PR DESCRIPTION
This commit updates a few tests that do not work with the latest version of nock. This should unblock the nock update.