### PR TITLE
FIX: Adding support for multiple client

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,7 @@ function fileExists(filepath: string): boolean {
 export interface ApiType {}
 
 export class KubeConfig implements SecurityAuthentication {
-    private static authenticators: Authenticator[] = [
+    private authenticators: Authenticator[] = [
         new AzureAuth(),
         new GoogleCloudPlatformAuth(),
         new ExecAuth(),
@@ -596,7 +596,7 @@ export class KubeConfig implements SecurityAuthentication {
         if (!user) {
             return;
         }
-        let authenticator = KubeConfig.authenticators.find((elt: Authenticator) => {
+        let authenticator = this.authenticators.find((elt: Authenticator) => {
             return elt.isAuthProvider(user);
         });
 

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1345,7 +1345,7 @@ describe('KubeConfig', () => {
             // TODO: inject the exec command here?
             const opts = {} as RequestOptions;
             await config.applyToHTTPSOptions(opts);
-            const execAuthenticator = (KubeConfig as any).authenticators.find(
+            const execAuthenticator = (config as any).authenticators.find(
                 (authenticator) => authenticator instanceof ExecAuth,
             );
             deepStrictEqual(execAuthenticator.tokenCache.exec, JSON.parse(responseStr));


### PR DESCRIPTION
I have found that while creating multiple client with different access in single application.
Both of the client overlap the credentials and start returning the 401 error. Whereas the client created with proper credentials. 

It is fixing old code https://github.com/kubernetes-client/javascript/issues/2512