### PR TITLE
fix: support YAML 1.1 parsing in Kubernetes manifests by replacing js-yaml with yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "form-data": "^4.0.0",
                 "hpagent": "^1.2.0",
                 "isomorphic-ws": "^5.0.0",
-                "js-yaml": "^4.1.0",
                 "jsonpath-plus": "^10.3.0",
                 "node-fetch": "^2.6.9",
                 "openid-client": "^6.1.3",
@@ -24,7 +23,8 @@
                 "socks-proxy-agent": "^8.0.4",
                 "stream-buffers": "^3.0.2",
                 "tar-fs": "^3.0.9",
-                "ws": "^8.18.2"
+                "ws": "^8.18.2",
+                "yaml": "^2.8.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.18.0",
@@ -1349,6 +1349,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/asynckit": {
@@ -2659,6 +2660,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -4022,7 +4024,7 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
             "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "dev": true,
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "form-data": "^4.0.0",
         "hpagent": "^1.2.0",
         "isomorphic-ws": "^5.0.0",
-        "js-yaml": "^4.1.0",
         "jsonpath-plus": "^10.3.0",
         "node-fetch": "^2.6.9",
         "openid-client": "^6.1.3",
@@ -70,7 +69,8 @@
         "socks-proxy-agent": "^8.0.4",
         "stream-buffers": "^3.0.2",
         "tar-fs": "^3.0.9",
-        "ws": "^8.18.2"
+        "ws": "^8.18.2",
+        "yaml": "^2.8.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.18.0",

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import YAML from 'yaml';
 import { getSerializationType } from './util.js';
 import { KubernetesObject } from './types.js';
 import { ObjectSerializer } from './serializer.js';
@@ -9,13 +9,12 @@ import { ObjectSerializer } from './serializer.js';
  * @param opts - Optional YAML load options.
  * @returns The deserialized Kubernetes object.
  */
-export function loadYaml<T>(data: string, opts?: yaml.LoadOptions): T {
-    const yml = yaml.load(data, opts) as any as KubernetesObject;
+export function loadYaml<T>(data: string): T {
+    const yml = YAML.parse(data, { version: '1.1' }) as any as KubernetesObject;
     if (!yml) {
         throw new Error('Failed to load YAML');
     }
     const type = getSerializationType(yml.apiVersion, yml.kind);
-
     return ObjectSerializer.deserialize(yml, type) as T;
 }
 
@@ -25,12 +24,12 @@ export function loadYaml<T>(data: string, opts?: yaml.LoadOptions): T {
  * @param opts - Optional YAML load options.
  * @returns An array of deserialized Kubernetes objects.
  */
-export function loadAllYaml(data: string, opts?: yaml.LoadOptions): any[] {
-    const ymls = yaml.loadAll(data, undefined, opts);
-    return ymls.map((yml) => {
-        const obj = yml as KubernetesObject;
+export function loadAllYaml(data: string): any[] {
+    const ymls = YAML.parseAllDocuments(data, { version: '1.1' });
+    return ymls.map((doc) => {
+        const obj = doc.toJS() as KubernetesObject;
         const type = getSerializationType(obj.apiVersion, obj.kind);
-        return ObjectSerializer.deserialize(yml, type);
+        return ObjectSerializer.deserialize(obj, type);
     });
 }
 
@@ -40,9 +39,9 @@ export function loadAllYaml(data: string, opts?: yaml.LoadOptions): any[] {
  * @param opts - Optional YAML dump options.
  * @returns The YAML string representation of the serialized Kubernetes object.
  */
-export function dumpYaml(object: any, opts?: yaml.DumpOptions): string {
+export function dumpYaml(object: any): string {
     const kubeObject = object as KubernetesObject;
     const type = getSerializationType(kubeObject.apiVersion, kubeObject.kind);
     const serialized = ObjectSerializer.serialize(kubeObject, type);
-    return yaml.dump(serialized, opts);
+    return YAML.stringify(serialized);
 }

--- a/src/yaml_test.ts
+++ b/src/yaml_test.ts
@@ -154,4 +154,39 @@ spec:
         // not using strict equality as types are not matching
         deepEqual(actual, expected);
     });
+
+    it('should parse octal-like strings as numbers (YAML 1.1 style)', () => {
+        const yaml = `
+    defaultMode: 0644
+    fileMode: 0755
+    `;
+        const result = loadYaml<{
+            defaultMode: number;
+            fileMode: number;
+        }>(yaml);
+
+        // 0644 (octal) = 420 decimal, 0755 = 493
+        strictEqual(result.defaultMode, 420);
+        strictEqual(result.fileMode, 493);
+    });
+
+    it('should parse boolean-like strings as booleans (YAML 1.1 style)', () => {
+        const yaml = `
+    enableFeature: yes
+    debugMode: ON
+    maintenance: no
+    safeMode: off
+    `;
+        const result = loadYaml<{
+            enableFeature: boolean;
+            debugMode: boolean;
+            maintenance: boolean;
+            safeMode: boolean;
+        }>(yaml);
+
+        strictEqual(result.enableFeature, true);
+        strictEqual(result.debugMode, true);
+        strictEqual(result.maintenance, false);
+        strictEqual(result.safeMode, false);
+    });
 });


### PR DESCRIPTION
🛠️ What’s Changed

Removed: js-yaml dependency

Added: yaml library

Updated manifest parsing logic to:

parseDocument(manifest, { version: '1.1' });
Ensures values are interpreted using YAML 1.1 rules.

🐛 Problems Solved

1. ✅ Incorrect parsing of octal values
defaultMode: 0644 was being parsed as 644 in YAML 1.2 (incorrect)

In YAML 1.1, it's correctly interpreted as octal 0644 → decimal 420

This fixes configMap and secret mount permission issues in Kubernetes

2. ✅ Boolean string interpretation issues
YAML 1.2 doesn't treat yes, no, on, off as booleans

In YAML 1.1, these are properly recognized as true/false

Prevents unexpected behavior in manifest logic that depends on boolean flags

### ✅ Tested
- Applied a manifest with `defaultMode: 0644` — parsed correctly as 420
- Applied a manifest with `on`, `yes`, `no` — parsed correctly as booleans
- Resource created successfully using KubernetesObjectApi


✅ Result
Manifests parsed through this library now match Kubernetes expectations

No more silent failures or misconfigurations due to YAML parsing issues
![Screenshot (312)](https://github.com/user-attachments/assets/f7a49c1a-77b5-493a-b4a6-7b16b9987bc0)


Fixes #2539 


