### PR TITLE
fix: do not overwrite process.env during API authentication

### DIFF
--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -95,7 +95,7 @@ export class ExecAuth implements Authenticator {
         }
         let opts = {};
         if (exec.env) {
-            const env = process.env;
+            const env = { ...process.env };
             exec.env.forEach((elt) => (env[elt.name] = elt.value));
             opts = { ...opts, env };
         }

--- a/src/exec_auth_test.ts
+++ b/src/exec_auth_test.ts
@@ -538,4 +538,63 @@ describe('ExecAuth', () => {
         const promise = auth.applyAuthentication(user, opts);
         await rejects(promise, { name: 'SyntaxError' });
     });
+
+    it('should not overwrite environment variables in process.env', async () => {
+        // TODO: fix this test for Windows
+        if (process.platform === 'win32') {
+            return;
+        }
+        const auth = new ExecAuth();
+        let optsOut: child_process.SpawnOptions | undefined = {};
+        (auth as any).execFn = (
+            command: string,
+            args?: readonly string[],
+            options?: child_process.SpawnOptionsWithoutStdio,
+        ): child_process.ChildProcessWithoutNullStreams => {
+            optsOut = options;
+            return {
+                stdout: {
+                    setEncoding: () => {},
+                    on: (_data: string, f: (data: Buffer | string) => void) => {
+                        f(Buffer.from(JSON.stringify({ status: { token: 'foo' } })));
+                    },
+                },
+                stderr: {
+                    setEncoding: () => {},
+                    on: () => {},
+                },
+                on: (op: string, f: any) => {
+                    if (op === 'close') {
+                        f(0);
+                    }
+                },
+            } as unknown as child_process.ChildProcessWithoutNullStreams;
+        };
+
+        process.env.DO_NO_OVERWRITE_ME = 'important';
+        const opts = {} as https.RequestOptions;
+        opts.headers = {} as OutgoingHttpHeaders;
+
+        await auth.applyAuthentication(
+            {
+                name: 'user',
+                authProvider: {
+                    config: {
+                        exec: {
+                            command: 'echo',
+                            env: [
+                                {
+                                    name: 'DO_NO_OVERWRITE_ME',
+                                    value: 'in exec',
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+            opts,
+        );
+        strictEqual(optsOut.env!.DO_NO_OVERWRITE_ME, 'in exec');
+        strictEqual(process.env.DO_NO_OVERWRITE_ME, 'important');
+    });
 });


### PR DESCRIPTION
Fix for #2579 