### PR TITLE
ci: test on Node v25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node: ['24', '23', '22', '20', '18']
+                node: ['25', '24', '23', '22', '20', '18']
         name: Node ${{ matrix.node }} validation
         steps:
             - uses: actions/checkout@v5.0.0


### PR DESCRIPTION
This commit adds the newly released v25 to the CI matrix.