### PR TITLE
fix: don't cast undefined expiration times in exec auth

### DIFF
--- a/src/exec_auth.ts
+++ b/src/exec_auth.ts
@@ -10,7 +10,7 @@ export interface CredentialStatus {
     readonly token: string;
     readonly clientCertificateData: string;
     readonly clientKeyData: string;
-    readonly expirationTimestamp: string;
+    readonly expirationTimestamp?: string;
 }
 
 export interface Credential {
@@ -74,6 +74,9 @@ export class ExecAuth implements Authenticator {
         // TODO: Add a unit test for token caching.
         const cachedToken = this.tokenCache[user.name];
         if (cachedToken) {
+            if (!cachedToken.status.expirationTimestamp) {
+                return cachedToken;
+            }
             const date = Date.parse(cachedToken.status.expirationTimestamp);
             if (date > Date.now()) {
                 return cachedToken;


### PR DESCRIPTION
I believe that expiration timestamp in exec auth does not always have to be defined from [the docs](https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#client-authentication-k8s-io-v1-ExecCredentialStatus) and [the go client](https://github.com/kubernetes/client-go/blob/6661e485ecc691ff868672f6d92b31c5aca86a4b/plugin/pkg/client/auth/exec/exec.go#L469)

This PR adjusts the type, adds the correct handling for undefined expiration times, and adds a unit test.