### PR TITLE
Update watch-example.ts to reflect `done` error is conditionally passed

### DIFF
--- a/examples/typescript/watch/watch-example.ts
+++ b/examples/typescript/watch/watch-example.ts
@@ -29,9 +29,9 @@ const req = await watch
         // done callback is called if the watch terminates either normally or with an error
         (err) => {
             if (err) {
-                console.log(err);
+                console.error(err);
             } else {
-                console.log('watch done')
+                console.log('watch finished normally')
             }
         },
     )


### PR DESCRIPTION
simple example change

There is very little documentation about this class online, so this example is pretty much the only usage (aside from looking at code) that explains the role of error param