### PR TITLE
chore: make pre-check work on `release-*` branches

### DIFF
--- a/pre-check.sh
+++ b/pre-check.sh
@@ -2,13 +2,13 @@
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ "${branch}" != "main" ]]; then
-  echo "This script can only be run on the main branch. Current branch is ${branch}"
+if [[ "${branch}" != "main" && ! "${branch}" =~ ^release- ]]; then
+  echo "This script can only be run on the main or release-* branches. Current branch is ${branch}"
   exit 1
 fi
 
 if ! git diff --quiet; then
-  echo "This script must only run on a clean main branch."
+  echo "This script must only run on a clean branch."
   echo
   git status
   exit 1


### PR DESCRIPTION
As discussed here: https://github.com/kubernetes-client/javascript/pull/2702
Updating the pre-check script to run on release branches.

Backports for current release branches (1.1 - 1.3):
* #2711 
* #2712 
* #2713 

Redacted output:

```sh
debian@box: /home/debian/projects/contrib/javascript git:(main)
➜   ./pre-check.sh
debian@box: /home/debian/projects/contrib/javascript git:(main)
➜   echo $?
0
debian@box: /home/debian/projects/contrib/javascript git:(main)
➜   git checkout release-1.1
Switched to branch 'release-1.1'
Your branch is up to date with 'origin/release-1.1'.
debian@box: /home/debian/projects/contrib/javascript git:(release-1.1)
➜   g cherry-pick 38b765883dd4ab0a9627fb6ee7288eabf7756cea
debian@box: /home/debian/projects/contrib/javascript git:(release-1.1)
➜   ./pre-check.sh
debian@box: /home/debian/projects/contrib/javascript git:(release-1.1)
➜   echo $?
0
debian@box: /home/debian/projects/contrib/javascript git:(release-1.1)
➜   g co main
Switched to branch 'main'
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)
debian@box: /home/debian/projects/contrib/javascript git:(main)
➜   g co -b max/succeed-pre-check-on-release-branch
Switched to a new branch 'max/succeed-pre-check-on-release-branch'
debian@box: /home/debian/projects/contrib/javascript git:(max/succeed-pre-check-on-release-branch)
➜   ./pre-check.sh
This script can only be run on the main or release-* branches. Current branch is max/succeed-pre-check-on-release-branch
```