### PR TITLE
[BACKPORT 1.2] chore: make pre-check work on `release-*` branches

### DIFF
--- a/pre-check.sh
+++ b/pre-check.sh
@@ -2,13 +2,13 @@
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ "${branch}" != "main" ]]; then
-  echo "This script can only be run on the main branch. Current branch is ${branch}"
+if [[ "${branch}" != "main" && ! "${branch}" =~ ^release- ]]; then
+  echo "This script can only be run on the main or release-* branches. Current branch is ${branch}"
   exit 1
 fi
 
 if ! git diff --quiet; then
-  echo "This script must only run on a clean master branch."
+  echo "This script must only run on a clean branch."
   echo
   git status
   exit 1


### PR DESCRIPTION
Backport of #2710 