### PR TITLE
ci: add `id-token: write` permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 permissions:
     contents: write
     actions: write
+    id-token: write
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
This adds an `id-token: write` permission on the GitHub action in order to be able to create oidc tokens (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)

See: https://github.com/kubernetes-client/javascript/pull/2702 

Let's test it in release-1.1 first as we have something ready to release here, if it is working I will do all the cherry-picks/forward-ports.