### PR TITLE
ci: update npm to be able to use trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,14 @@ jobs:
               run: npm install
             - name: Package
               run: ./build-package.sh
+            - name: Update npm
+              run: npm install -g npm@11.5.1
             - name: Upload release
               if: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.pre_release != 'true' }}
               run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
             - name: Upload pre-release
               if: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.pre_release == 'true' }}
               run: npm publish --tag next
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
             - name: Tag release
               if: ${{ github.event.inputs.skip_tag != 'true' }}
               run: |


### PR DESCRIPTION
After a bit of digging I've found out that trusted publishers needs a minimum npm version to work.
I've tried it in a repository and was able to publish something:

https://github.com/mstruebing/npm-publish-test
https://www.npmjs.com/package/@mstruebing/npm-publish-test/access

Here is the GitHub discussion which made me aware of the issue that npm is to old: https://github.com/orgs/community/discussions/173102

I've tried it with node 25 as well and it is working without an npm update, but I did not want to use the latest node version in CI in this old branch as well as I didn't want to install `@latest` npm as it could lead to problems.

I hope this is the last missing piece here.

reference: #2702 