### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 permissions:
     contents: write
     actions: write
+    id-token: write
 
 on:
     workflow_dispatch:
@@ -37,7 +38,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v6
               with:
-                  node-version: '20'
+                  node-version: '25'
                   registry-url: 'https://registry.npmjs.org'
             - name: Install dependencies
               run: npm install
@@ -45,14 +46,10 @@ jobs:
               run: ./build-package.sh
             - name: Upload release
               if: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.pre_release != 'true' }}
-              run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+              run: npm publish --tag latest
             - name: Upload pre-release
               if: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.pre_release == 'true' }}
               run: npm publish --tag next
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
             - name: Tag release
               if: ${{ github.event.inputs.skip_tag != 'true' }}
               run: |


### PR DESCRIPTION
This should enable trusted publishing on `main` so we are not dependent on @brendanburns updating the npm token anymore. 🚀 

In my test-repo it worked with NodeJS 25 out of the box as it seems to contain the minimum required npm version.
As we are running our tests with NodeJS 25 as well I don't think it's a problem to increase the version in here as well.

As this is `main` we use the tag latest, I explicitly added it so that whenever we need to release from an older branch again and get an error it's easier to spot whats wrong.

I don't really bother to adjust the other release branches release workflow, we seldom release patch versions and if we really need to, we can make these adjustments.