### PR TITLE
ci: set contents and pull-requests write permissions for gen javascript

### DIFF
--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -1,56 +1,56 @@
 name: Generate
 
 on:
-    workflow_dispatch:
-        inputs:
-            kubernetesBranch:
-                type: string
-                required: true
-                description: 'The remote kubernetes release branch to fetch openapi spec. .e.g. "release-1.23"'
-            genCommit:
-                type: string
-                required: true
-                default: 'b461333bb57fa2dc2152f939ed70bac3cef2c1f6'
-                description: 'The commit to use for the kubernetes-client/gen repo'
+  workflow_dispatch:
+    inputs:
+      kubernetesBranch:
+        type: string
+        required: true
+        description: 'The remote kubernetes release branch to fetch openapi spec. .e.g. "release-1.23"'
+      genCommit:
+        type: string
+        required: true
+        default: 'b461333bb57fa2dc2152f939ed70bac3cef2c1f6'
+        description: 'The commit to use for the kubernetes-client/gen repo'
 
 permissions:
-    contents: write
-    pull-requests: write
+  contents: write
+  pull-requests: write
 
 jobs:
-    generate:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Javascript
-              uses: actions/checkout@v6.0.1
-            - name: Setup Node
-              uses: actions/setup-node@v6
-              with:
-                  node-version: '20'
-            - name: Generate Openapi
-              run: |
-                  echo "export KUBERNETES_BRANCH=${{ github.event.inputs.kubernetesBranch }}" >> ./settings
-                  echo "export GEN_COMMIT=${{ github.event.inputs.genCommit }}" >> ./settings
-                  ./generate-client.sh
-            - name: Generate Branch Name
-              run: |
-                  SUFFIX=$(openssl rand -hex 4)
-                  echo "BRANCH=automated-generate-$SUFFIX" >> $GITHUB_ENV
-            - name: Commit and push
-              run: |
-                  # Commit and push
-                  git config user.email "k8s.ci.robot@gmail.com"
-                  git config user.name "Kubernetes Prow Robot"
-                  git checkout -b "$BRANCH"
-                  git add .
-                  # we modify the settings file in "Generate Openapi" but do not want to commit this
-                  git reset settings
-                  git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
-                  git push origin "$BRANCH"
-            - name: Pull Request
-              uses: repo-sync/pull-request@v2
-              with:
-                  source_branch: ${{ env.BRANCH }}
-                  destination_branch: ${{ github.ref_name }}
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  pr_title: 'Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}'
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Javascript
+        uses: actions/checkout@v6.0.1
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - name: Generate Openapi
+        run: |
+          echo "export KUBERNETES_BRANCH=${{ github.event.inputs.kubernetesBranch }}" >> ./settings
+          echo "export GEN_COMMIT=${{ github.event.inputs.genCommit }}" >> ./settings
+          ./generate-client.sh
+      - name: Generate Branch Name
+        run: |
+          SUFFIX=$(openssl rand -hex 4)
+          echo "BRANCH=automated-generate-$SUFFIX" >> $GITHUB_ENV
+      - name: Commit and push
+        run: |
+          # Commit and push
+          git config user.email "k8s.ci.robot@gmail.com"
+          git config user.name "Kubernetes Prow Robot"
+          git checkout -b "$BRANCH"
+          git add .
+          # we modify the settings file in "Generate Openapi" but do not want to commit this
+          git reset settings
+          git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
+          git push origin "$BRANCH"
+      - name: Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: ${{ env.BRANCH }}
+          destination_branch: ${{ github.ref_name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}"


### PR DESCRIPTION
Tried to generate the javascript with the new 1.35 release, got 

```
remote: Permission to kubernetes-client/javascript.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kubernetes-client/javascript/': The requested URL returned error: 403
```

https://github.com/kubernetes-client/javascript/actions/runs/20322729134/job/58381714389