### PR TITLE
add useragent with package version

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,7 @@ const USER_AGENT_KEY = 'User-Agent';
 
 function getUserAgent(): string {
     const version = packagejson.version ?? '';
-    return `kubernetes-javascript-client/${version}`;
+    return `kubernetes-client-javascript/${version}`;
 }
 
 // fs.existsSync was removed in node 10

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -1691,6 +1691,11 @@ describe('KubeConfig', () => {
                     }),
                 );
             });
+            t.after(async () => {
+                await new Promise<Error | undefined>((resolve) => {
+                    server.close(resolve);
+                });
+            });
 
             const kc = new KubeConfig();
             kc.loadFromClusterAndUser(
@@ -1720,7 +1725,7 @@ describe('KubeConfig', () => {
             // Verify User-Agent header contains client name and version
             strictEqual(typeof capturedUserAgent, 'string');
             strictEqual(
-                capturedUserAgent!.startsWith('kubernetes-javascript-client/'),
+                capturedUserAgent!.startsWith('kubernetes-client-javascript/'),
                 true,
                 'capturedUserAgent should start with "kubernetes-javascript-client/"',
             );
@@ -1729,11 +1734,6 @@ describe('KubeConfig', () => {
                 true,
                 `User-Agent should include version ${expectedVersion}`,
             );
-            t.after(async () => {
-                await new Promise<Error | undefined>((resolve) => {
-                    server.close(resolve);
-                });
-            });
         });
     });
 


### PR DESCRIPTION
make debugging easier by including a user agent with package version

following similar pattern to go client https://github.com/kubernetes/client-go/blob/0b06cf5bf0e19c0f026fd5eef7eecb5a346ca95f/rest/config.go#L524