### PR TITLE
pin actions to sha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,21 @@ updates:
       schedule:
           interval: 'daily'
           time: '02:00'
+      cooldown:
+          default-days: 7
       target-branch: 'main'
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:
           interval: 'daily'
           time: '03:00'
+      cooldown:
+          default-days: 7
       target-branch: 'main'
     - package-ecosystem: 'devcontainers'
       directory: '/'
       schedule:
           interval: 'weekly'
+      cooldown:
+          default-days: 7
       target-branch: 'main'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,15 +38,15 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
               with:
                   languages: ${{ matrix.language }}
 
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v4
+              uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,15 +21,16 @@ on:
     schedule:
         - cron: '35 14 * * 3'
 
-permissions:
-    actions: read
-    contents: read
-    security-events: write
+permissions: {}
 
 jobs:
     analyze:
         name: Analyze
         runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
 
         strategy:
             fail-fast: false
@@ -39,6 +40,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,9 +8,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: '20'
             # Pre-check to validate that versions match between package.json
@@ -23,7 +23,7 @@ jobs:
               run: npm run docs
 
             - name: Deploy docs
-              uses: JamesIves/github-pages-deploy-action@v4.8.0
+              uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
               with:
                   branch: gh-pages # The branch the action should deploy to.
                   folder: docs # The folder the action should deploy.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,12 +3,19 @@ on:
     push:
         branches:
             - main
+
+permissions: {}
+
 jobs:
     build-and-deploy-docs:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Setup Node.js
               uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:

--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -20,10 +20,12 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write # Push generated branch
-            pull-requests: write # Create PR via repo-sync/pull-request
+            pull-requests: write # Create PR via gh CLI
         steps:
             - name: Checkout Javascript
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Setup Node
               uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
@@ -50,13 +52,19 @@ jobs:
                   # we modify the settings file in "Generate Openapi" but do not want to commit this
                   git reset settings
                   git commit -s -m "Automated openapi generation from ${KUBERNETES_BRANCH}"
+                  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
                   git push origin "$BRANCH"
               env:
                   KUBERNETES_BRANCH: ${{ github.event.inputs.kubernetesBranch }}
-            - name: Pull Request
-              uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
-              with:
-                  source_branch: ${{ env.BRANCH }}
-                  destination_branch: ${{ github.ref_name }}
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  pr_title: 'Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}'
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Create Pull Request
+              run: |
+                  gh pr create \
+                    --base "${BASE_BRANCH}" \
+                    --head "$BRANCH" \
+                    --title "Automated Generate from openapi ${KUBERNETES_BRANCH}" \
+                    --body "Automated openapi generation from ${KUBERNETES_BRANCH}"
+              env:
+                  KUBERNETES_BRANCH: ${{ github.event.inputs.kubernetesBranch }}
+                  BASE_BRANCH: ${{ github.ref_name }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -13,13 +13,14 @@ on:
                 default: 'b461333bb57fa2dc2152f939ed70bac3cef2c1f6'
                 description: 'The commit to use for the kubernetes-client/gen repo'
 
-permissions:
-    contents: write
-    pull-requests: write
+permissions: {}
 
 jobs:
     generate:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write # Push generated branch
+            pull-requests: write # Create PR via repo-sync/pull-request
         steps:
             - name: Checkout Javascript
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,9 +30,12 @@ jobs:
                   node-version: '20'
             - name: Generate Openapi
               run: |
-                  echo "export KUBERNETES_BRANCH=${{ github.event.inputs.kubernetesBranch }}" >> ./settings
-                  echo "export GEN_COMMIT=${{ github.event.inputs.genCommit }}" >> ./settings
+                  echo "export KUBERNETES_BRANCH=${KUBERNETES_BRANCH}" >> ./settings
+                  echo "export GEN_COMMIT=${GEN_COMMIT}" >> ./settings
                   ./generate-client.sh
+              env:
+                  KUBERNETES_BRANCH: ${{ github.event.inputs.kubernetesBranch }}
+                  GEN_COMMIT: ${{ github.event.inputs.genCommit }}
             - name: Generate Branch Name
               run: |
                   SUFFIX=$(openssl rand -hex 4)
@@ -45,8 +49,10 @@ jobs:
                   git add .
                   # we modify the settings file in "Generate Openapi" but do not want to commit this
                   git reset settings
-                  git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
+                  git commit -s -m "Automated openapi generation from ${KUBERNETES_BRANCH}"
                   git push origin "$BRANCH"
+              env:
+                  KUBERNETES_BRANCH: ${{ github.event.inputs.kubernetesBranch }}
             - name: Pull Request
               uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
               with:

--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -1,56 +1,56 @@
 name: Generate
 
 on:
-  workflow_dispatch:
-    inputs:
-      kubernetesBranch:
-        type: string
-        required: true
-        description: 'The remote kubernetes release branch to fetch openapi spec. .e.g. "release-1.23"'
-      genCommit:
-        type: string
-        required: true
-        default: 'b461333bb57fa2dc2152f939ed70bac3cef2c1f6'
-        description: 'The commit to use for the kubernetes-client/gen repo'
+    workflow_dispatch:
+        inputs:
+            kubernetesBranch:
+                type: string
+                required: true
+                description: 'The remote kubernetes release branch to fetch openapi spec. .e.g. "release-1.23"'
+            genCommit:
+                type: string
+                required: true
+                default: 'b461333bb57fa2dc2152f939ed70bac3cef2c1f6'
+                description: 'The commit to use for the kubernetes-client/gen repo'
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 jobs:
-  generate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Javascript
-        uses: actions/checkout@v6.0.2
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-      - name: Generate Openapi
-        run: |
-          echo "export KUBERNETES_BRANCH=${{ github.event.inputs.kubernetesBranch }}" >> ./settings
-          echo "export GEN_COMMIT=${{ github.event.inputs.genCommit }}" >> ./settings
-          ./generate-client.sh
-      - name: Generate Branch Name
-        run: |
-          SUFFIX=$(openssl rand -hex 4)
-          echo "BRANCH=automated-generate-$SUFFIX" >> $GITHUB_ENV
-      - name: Commit and push
-        run: |
-          # Commit and push
-          git config user.email "k8s.ci.robot@gmail.com"
-          git config user.name "Kubernetes Prow Robot"
-          git checkout -b "$BRANCH"
-          git add .
-          # we modify the settings file in "Generate Openapi" but do not want to commit this
-          git reset settings
-          git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
-          git push origin "$BRANCH"
-      - name: Pull Request
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: ${{ env.BRANCH }}
-          destination_branch: ${{ github.ref_name }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: "Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}"
+    generate:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Javascript
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - name: Setup Node
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+              with:
+                  node-version: '20'
+            - name: Generate Openapi
+              run: |
+                  echo "export KUBERNETES_BRANCH=${{ github.event.inputs.kubernetesBranch }}" >> ./settings
+                  echo "export GEN_COMMIT=${{ github.event.inputs.genCommit }}" >> ./settings
+                  ./generate-client.sh
+            - name: Generate Branch Name
+              run: |
+                  SUFFIX=$(openssl rand -hex 4)
+                  echo "BRANCH=automated-generate-$SUFFIX" >> $GITHUB_ENV
+            - name: Commit and push
+              run: |
+                  # Commit and push
+                  git config user.email "k8s.ci.robot@gmail.com"
+                  git config user.name "Kubernetes Prow Robot"
+                  git checkout -b "$BRANCH"
+                  git add .
+                  # we modify the settings file in "Generate Openapi" but do not want to commit this
+                  git reset settings
+                  git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
+                  git push origin "$BRANCH"
+            - name: Pull Request
+              uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
+              with:
+                  source_branch: ${{ env.BRANCH }}
+                  destination_branch: ${{ github.ref_name }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  pr_title: 'Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
         steps:
             - name: Checkout Javascript
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Setup Node
               uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
@@ -62,6 +64,8 @@ jobs:
             - name: Push tag
               if: ${{ github.event.inputs.dry_run != 'true' }}
               run: |
+                  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
                   git push origin "${RELEASE_VERSION}"
               env:
                   RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
         environment: production
         steps:
             - name: Checkout Javascript
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: '25'
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
-permissions:
-    contents: write
-    actions: write
-    id-token: write
+permissions: {}
 
 on:
     workflow_dispatch:
@@ -32,6 +29,10 @@ jobs:
     release:
         runs-on: ubuntu-latest
         environment: production
+        permissions:
+            contents: write # Push tags to the repository
+            actions: write # Trigger downstream workflows
+            id-token: write # npm provenance via OIDC
         steps:
             - name: Checkout Javascript
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -55,8 +56,12 @@ jobs:
               run: |
                   git config --global user.name 'Github Bot'
                   git config --global user.email '<>'
-                  git tag ${{ github.event.inputs.releaseVersion }}
+                  git tag "${RELEASE_VERSION}"
+              env:
+                  RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
             - name: Push tag
               if: ${{ github.event.inputs.dry_run != 'true' }}
               run: |
-                  git push origin ${{ github.event.inputs.releaseVersion }}
+                  git push origin "${RELEASE_VERSION}"
+              env:
+                  RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,21 @@ on:
     pull_request:
         branches: [master, main]
 
+permissions: {}
+
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         strategy:
             matrix:
                 node: ['25', '24', '23', '22', '20', '18']
         name: Node ${{ matrix.node }} validation
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: ${{ matrix.node }}
@@ -48,3 +54,4 @@ jobs:
               with:
                   advanced-security: false
                   persona: pedantic
+                  min-severity: medium

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
                 node: ['25', '24', '23', '22', '20', '18']
         name: Node ${{ matrix.node }} validation
         steps:
-            - uses: actions/checkout@v6.0.2
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version: ${{ matrix.node }}
             # Pre-check to validate that versions match between package.json
@@ -33,5 +33,18 @@ jobs:
             - run: npm audit --audit-level=critical
             - run: npm run build-with-tests && npm run test-transpiled
             - name: Create k8s Kind Cluster
-              uses: helm/kind-action@v1
+              uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
             - run: npm run integration-test
+    zizmor:
+        runs-on: ubuntu-latest
+        name: GitHub Actions security lint
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+            - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+              with:
+                  advanced-security: false
+                  persona: pedantic


### PR DESCRIPTION
to follow guidance from https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md

added [zizmor](https://github.com/zizmorcore/zizmor) lint step validating SHAs exist and match

if people would prefer to hold off on the lint step i can reduce PR scope to just the pinned SHAs, i added linting to give some way to validate the SHAs are correct

> All GitHub Actions MUST be referenced using commit SHA hashes.

using zizmor in the meantime to lint. this will likely be applied via repo/org settings in the future and we can drop that dependency from the test workflow

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository