### PR TITLE
fix: merge global agent CA certificates with cluster-specific ones

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -648,7 +648,23 @@ export class KubeConfig implements SecurityAuthentication {
         agentOptions: https.AgentOptions,
     ): DispatcherOptions {
         const tlsOptions: tls.ConnectionOptions = {};
-        if (agentOptions.ca !== undefined) tlsOptions.ca = agentOptions.ca;
+        // Merge global agent CA certificates with cluster-specific ones
+        const globalCA = (https.globalAgent as https.Agent).options?.ca;
+        if (globalCA !== undefined) {
+            tlsOptions.ca = globalCA;
+        }
+        if (agentOptions.ca !== undefined) {
+            // If both global and cluster CA exist, concatenate them
+            if (tlsOptions.ca !== undefined) {
+                const globalCAs = Array.isArray(tlsOptions.ca) ? tlsOptions.ca : [tlsOptions.ca];
+                const clusterCAs = Array.isArray(agentOptions.ca) ? agentOptions.ca : [agentOptions.ca];
+                tlsOptions.ca = Buffer.concat(
+                    [...globalCAs, ...clusterCAs].map((ca) => (Buffer.isBuffer(ca) ? ca : Buffer.from(ca))),
+                );
+            } else {
+                tlsOptions.ca = agentOptions.ca;
+            }
+        }
         if (agentOptions.cert !== undefined) tlsOptions.cert = agentOptions.cert;
         if (agentOptions.key !== undefined) tlsOptions.key = agentOptions.key;
         if (agentOptions.pfx !== undefined) tlsOptions.pfx = agentOptions.pfx;

--- a/src/config_test.ts
+++ b/src/config_test.ts
@@ -565,6 +565,64 @@ describe('KubeConfig', () => {
                 message: 'Unsupported proxy type',
             });
         });
+        it('should merge global agent CA with cluster CA', async () => {
+            const kc = new KubeConfig();
+            kc.loadFromFile(kcFileName);
+
+            // Set a global CA
+            const globalCA = Buffer.from('GLOBAL_CA_DATA');
+            const originalGlobalCA = (https.globalAgent as https.Agent).options?.ca;
+            (https.globalAgent as https.Agent).options.ca = globalCA;
+
+            try {
+                const clusterCA = Buffer.from('CADATA2', 'utf-8');
+                const dispatcherOpts = kc.createDispatcherOptions(kc.getCurrentCluster(), {
+                    ca: clusterCA,
+                    cert: undefined,
+                    key: undefined,
+                });
+
+                strictEqual(dispatcherOpts.type, 'agent');
+                // The CA should be a Buffer containing both global and cluster CA data
+                const combinedCA = dispatcherOpts.connect.ca as Buffer;
+                strictEqual(combinedCA.includes('GLOBAL_CA_DATA'), true);
+                strictEqual(combinedCA.includes('CADATA2'), true);
+            } finally {
+                // Restore original global CA
+                if (originalGlobalCA !== undefined) {
+                    (https.globalAgent as https.Agent).options.ca = originalGlobalCA;
+                } else {
+                    delete (https.globalAgent as https.Agent).options.ca;
+                }
+            }
+        });
+        it('should use global CA when no cluster CA is provided', async () => {
+            const kc = new KubeConfig();
+            kc.loadFromFile(kcFileName);
+
+            // Set a global CA
+            const globalCA = Buffer.from('GLOBAL_CA_DATA_ONLY');
+            const originalGlobalCA = (https.globalAgent as https.Agent).options?.ca;
+            (https.globalAgent as https.Agent).options.ca = globalCA;
+
+            try {
+                const dispatcherOpts = kc.createDispatcherOptions(kc.getCurrentCluster(), {
+                    cert: undefined,
+                    key: undefined,
+                });
+
+                strictEqual(dispatcherOpts.type, 'agent');
+                // The CA should be the global CA only
+                strictEqual(dispatcherOpts.connect.ca?.toString(), 'GLOBAL_CA_DATA_ONLY');
+            } finally {
+                // Restore original global CA
+                if (originalGlobalCA !== undefined) {
+                    (https.globalAgent as https.Agent).options.ca = originalGlobalCA;
+                } else {
+                    delete (https.globalAgent as https.Agent).options.ca;
+                }
+            }
+        });
         it('should throw if cluster.server starts with http and skipTLSVerify is not set via applyToHTTPSOptions', async () => {
             const kc = new KubeConfig();
             kc.loadFromFile(kcProxyUrl);


### PR DESCRIPTION
## Description

When system certificates are configured through the global https.agent, they were being ignored by the kubernetes-client because it provides its own dispatcher to undici. This PR merges the global agent's CA certificates with any cluster-specific CA certificates, ensuring that custom CAs configured via the global agent are respected.

## Changes

- Modified `createDispatcherOptions` in `src/config.ts` to:
  - Read CA certificates from `https.globalAgent.options.ca`
  - Merge global CA with cluster-specific CA by concatenating them
  - Handle both Buffer and string CA formats, as well as arrays

## Testing

Added two new test cases:
1. `should merge global agent CA with cluster CA` - verifies that when both global and cluster CAs are present, they are concatenated
2. `should use global CA when no cluster CA is provided` - verifies that global CA is used when no cluster CA is specified

## Related Issue

Fixes #2546