### PR TITLE
introduce Node 26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version: '25'
+                  node-version: '26'
                   registry-url: 'https://registry.npmjs.org'
             - name: Install dependencies
               run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             contents: read
         strategy:
             matrix:
-                node: ['25', '24', '22']
+                node: ['26', '25', '24', '22']
         name: Node ${{ matrix.node }} validation
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,12 +46,12 @@ jobs:
             # and package-lock.json. Needs to run before npm install
             - run: node version-check.js
             - run: npm ci
-            # Node 25 has a known incompatibility: extension-less files in "type: module"
+            # Node 26 has a known incompatibility: extension-less files in "type: module"
             # packages are treated as ESM, causing c8's require('yargs/yargs') to fail.
-            # Fall back to plain unit tests without coverage on Node 25 until upstream fixes this.
-            - if: matrix.node != '25'
+            # Fall back to plain unit tests without coverage on Node 26 until upstream fixes this.
+            - if: matrix.node != '26'
               run: npm test
-            - if: matrix.node == '25'
+            - if: matrix.node == '26'
               run: npm run test-no-coverage
             - run: npm run lint
             - run: npm audit --audit-level=critical


### PR DESCRIPTION
Node 26 has been released. This commit updates the GitHub Actions workflows to leverage. It is worth noting that c8 (yargs more specifically) is broken on Node 26. The change that caused the problem in Node 25 was reverted on that branch, but still exists in Node 26.

Ref: https://github.com/nodejs/node/pull/62083#issuecomment-4381839266