### PR TITLE
allow workflow to write PRs

### DIFF
--- a/.github/workflows/generate-javascript.yml
+++ b/.github/workflows/generate-javascript.yml
@@ -13,7 +13,8 @@ on:
                 default: 'b461333bb57fa2dc2152f939ed70bac3cef2c1f6'
                 description: 'The commit to use for the kubernetes-client/gen repo'
 
-permissions: {}
+permissions:
+    pull-requests: write
 
 jobs:
     generate:


### PR DESCRIPTION
I've tried to regen with kubernetes release-1.35 but it seems like we can not create a PR from the workflow:
https://github.com/kubernetes-client/javascript/actions/runs/25906285452/job/76140710609#step:7:14

We may need to additionally check this box, but I don't know how
<img width="815" height="372" alt="Screenshot 2026-05-15 at 09 45 01" src="https://github.com/user-attachments/assets/25a84ef4-9d0e-4fba-9f13-ba63be561267" />


This was done in preparation of #2845
