### PR TITLE
docs: fix readNamespace/deleteNamespace calls in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ k8sApi.createNamespace({ body: namespace }).then(
     (response) => {
         console.log('Created namespace');
         console.log(response);
-        k8sApi.readNamespace(namespace.metadata.name).then((response) => {
+        k8sApi.readNamespace({ name: namespace.metadata.name }).then((response) => {
             console.log(response);
-            k8sApi.deleteNamespace(namespace.metadata.name, {} /* delete options */);
+            k8sApi.deleteNamespace({ name: namespace.metadata.name });
         });
     },
     (err) => {


### PR DESCRIPTION
The "Create a namespace" example in the README mixes API call styles.

`makeApiClient(k8s.CoreV1Api)` returns the object-parameter API (`gen/index.ts` exports `ObjectCoreV1Api as CoreV1Api`), so every method takes a single request object. The example gets `createNamespace({ body: namespace })` right, but the following calls don't:

- `readNamespace(namespace.metadata.name)` — the signature is `readNamespace(param: CoreV1ApiReadNamespaceRequest)`, and that interface requires `{ name: string }`. Passing a bare string is a type error and `param.name` ends up undefined at runtime.
- `deleteNamespace(namespace.metadata.name, {})` — same problem; `deleteNamespace(param: CoreV1ApiDeleteNamespaceRequest)` also requires `{ name }`.

This updates both to `{ name: namespace.metadata.name }` so the example type-checks and runs against the current API. Docs-only, no generated code touched.

```release-note
NONE
```