### PR TITLE
bump yargs 17.7.3  to fix release release workflow and c8 node26 compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,7 @@ jobs:
             # and package-lock.json. Needs to run before npm install
             - run: node version-check.js
             - run: npm ci
-            # Node 26 has a known incompatibility: extension-less files in "type: module"
-            # packages are treated as ESM, causing c8's require('yargs/yargs') to fail.
-            # Fall back to plain unit tests without coverage on Node 26 until upstream fixes this.
-            - if: matrix.node != '26'
-              run: npm test
-            - if: matrix.node == '26'
-              run: npm run test-no-coverage
+            - run: npm test
             - run: npm run lint
             - run: npm audit --audit-level=critical
             - run: npm run build-with-tests && npm run test-transpiled

--- a/build-package.sh
+++ b/build-package.sh
@@ -11,7 +11,7 @@ npm install
 
 # pre-requisites
 npm run lint
-npm test
+npm test-no-coverage #TODO revert to npm test when c8 is fixed
 
 # clean any old files
 npm run clean

--- a/build-package.sh
+++ b/build-package.sh
@@ -11,7 +11,7 @@ npm install
 
 # pre-requisites
 npm run lint
-npm test-no-coverage #TODO revert to npm test when c8 is fixed
+npm test
 
 # clean any old files
 npm run clean

--- a/package-lock.json
+++ b/package-lock.json
@@ -3324,9 +3324,9 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
release 17.7.3 of yargs fixes #2848

remove test-no-coverage script as new yargs patch version fixes previous issue with extensions

c8 coverage works on node26 again which will unblock release workflow that's failing on c8

https://github.com/yargs/yargs/pull/2514
https://github.com/yargs/yargs/releases/tag/v17.7.3