### PR TITLE
group codeql actions for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       cooldown:
           default-days: 7
       target-branch: 'main'
+      groups:
+          codeql-action:
+              patterns:
+                  - 'github/codeql-action*'
     - package-ecosystem: 'devcontainers'
       directory: '/'
       schedule:


### PR DESCRIPTION
We've had this a couple of times already that dependabot updates all three code ql actions in separate PRs but they only work together. This should let dependabot group them together in a single pr.