### PR TITLE
ci: fix zizmor template-injection findings blocking all open PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,16 @@ jobs:
             - name: Run prebuild
               run: cd docs && npm run prebuild
             - name: Create version snapshot
-              run: cd docs && npx docusaurus docs:version ${{ github.event.inputs.releaseVersion }}
+              run: cd docs && npx docusaurus docs:version "${RELEASE_VERSION}"
+              env:
+                  RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
             - name: Commit versioned docs
               if: ${{ github.event.inputs.dry_run != 'true' }}
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add docs/versions.json docs/versioned_docs/ docs/versioned_sidebars/
-                  git commit -m "docs: snapshot version ${{ github.ref_name }}" || echo "No changes to commit"
+                  git commit -m "docs: snapshot version ${REF_NAME}" || echo "No changes to commit"
                   git push
+              env:
+                  REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,17 +53,3 @@ jobs:
             - name: Create k8s Kind Cluster
               uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
             - run: npm run integration-test
-    zizmor:
-        runs-on: ubuntu-latest
-        name: GitHub Actions security lint
-        permissions:
-            contents: read
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-              with:
-                  persist-credentials: false
-            - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
-              with:
-                  advanced-security: false
-                  persona: pedantic
-                  min-severity: medium

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Zizmor
+
+# Deliberately unfiltered by `paths`. This job audits everything under
+# .github/, so gating it on a path list means a change to a workflow can
+# skip the lint that guards that very workflow -- which is how two
+# high-severity template-injection findings reached main unnoticed.
+on:
+    push:
+        branches: [master, main]
+    pull_request:
+        branches: [master, main]
+
+permissions: {}
+
+jobs:
+    zizmor:
+        runs-on: ubuntu-latest
+        name: GitHub Actions security lint
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+            - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+              with:
+                  advanced-security: false
+                  persona: pedantic
+                  min-severity: medium


### PR DESCRIPTION
The `zizmorcore/zizmor-action` step fails on every open dependabot PR (#3002, #2997, #2996). The bumps are not the cause — the findings are pre-existing on `main` and reproduce against an unmodified checkout.

## Cause

`release.yml` interpolates `${{ github.event.inputs.releaseVersion }}` and `${{ github.ref_name }}` directly into `run:` blocks (lines 77 and 84, added in #2911). zizmor's [`template-injection`](https://docs.zizmor.sh/audits/#template-injection) audit rates both **high**, so the job exits 14.

Those findings reached `main` because the zizmor job lived in `test.yml` behind a `paths:` filter covering only `src/**`, `testdata/**`, the package/tsconfig/eslint files and `test.yml` itself. A change to `release.yml` therefore could not trigger the lint that audits `release.yml`, and the regression merged green. Every later PR that *does* touch a filtered path — i.e. every dependabot npm PR — then failed on findings it did not introduce.

The differing errors between PRs are the same root cause seen against different bases: #2996/#2997 ran while `deploy-docs-v2.yml` still existed and additionally reported `excessive-permissions` on its workflow-level `contents: write`; that file has since been removed, so #3002 shows only the two `release.yml` findings.

## Changes

- **`release.yml`** — pass both expressions through `env:` and reference them as shell variables, matching the pattern already used by the `Tag release` and `Push tag` steps in the same file. No behaviour change.
- **`zizmor.yml`** (new) — move the job out of `test.yml` and run it on all pushes and pull requests with no `paths:` filter, so a workflow change can no longer skip the lint that guards it. The job name is unchanged, and only `EasyCLA` is a required status context, so no required check is affected.

## Verification

Ran the exact image CI uses (`zizmor v1.29.0`, `--persona pedantic --min-severity medium`) against the tree before and after:

```
before: 15 findings (13 ignored, 2 unsafe fixes): 0 medium, 2 high  → exit 14
after:  No findings to report. Good job! (14 ignored)               → exit 0
```

## Notes for the reviewer

- The commit message at `release.yml:84` uses `github.ref_name`, which on a `workflow_dispatch` run is the dispatched branch — so the message reads `docs: snapshot version main` rather than the release version. Preserved as-is here since it is a behaviour question, not a lint one, but it looks unintended.
- `zizmor-action` still resolves the zizmor binary as `version: latest` (its default), so a future zizmor release adding audits can surface new findings on unrelated PRs. Pinning would trade that off against the lint going stale; left unchanged, but worth a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)