### PR TITLE
ci: fix failing zizmor issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,16 @@ jobs:
             - name: Run prebuild
               run: cd docs && npm run prebuild
             - name: Create version snapshot
-              run: cd docs && npx docusaurus docs:version ${{ github.event.inputs.releaseVersion }}
+              run: cd docs && npx docusaurus docs:version "${RELEASE_VERSION}"
+              env:
+                  RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
             - name: Commit versioned docs
               if: ${{ github.event.inputs.dry_run != 'true' }}
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add docs/versions.json docs/versioned_docs/ docs/versioned_sidebars/
-                  git commit -m "docs: snapshot version ${{ github.ref_name }}" || echo "No changes to commit"
+                  git commit -m "docs: snapshot version ${REF_NAME}" || echo "No changes to commit"
                   git push
+              env:
+                  REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,17 +53,3 @@ jobs:
             - name: Create k8s Kind Cluster
               uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
             - run: npm run integration-test
-    zizmor:
-        runs-on: ubuntu-latest
-        name: GitHub Actions security lint
-        permissions:
-            contents: read
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-              with:
-                  persist-credentials: false
-            - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
-              with:
-                  advanced-security: false
-                  persona: pedantic
-                  min-severity: medium

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Zizmor
+
+# Deliberately unfiltered by `paths`. This job audits everything under
+# .github/, so gating it on a path list means a change to a workflow can
+# skip the lint that guards that very workflow -- which is how two
+# high-severity template-injection findings reached main unnoticed.
+on:
+    push:
+        branches: [master, main]
+    pull_request:
+        branches: [master, main]
+
+permissions: {}
+
+jobs:
+    zizmor:
+        runs-on: ubuntu-latest
+        name: GitHub Actions security lint
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+            - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+              with:
+                  advanced-security: false
+                  persona: pedantic
+                  min-severity: medium


### PR DESCRIPTION
Use `env` to inject runner variables and extract zizmor action