### PR TITLE
ci(docs): defer versioned docs to a future TODO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,21 +69,7 @@ jobs:
               env:
                   RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Install docs dependencies
-              run: cd docs && npm ci
-            - name: Run prebuild
-              run: cd docs && npm run prebuild
-            - name: Create version snapshot
-              run: cd docs && npx docusaurus docs:version "${RELEASE_VERSION}"
-              env:
-                  RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
-            - name: Commit versioned docs
-              if: ${{ github.event.inputs.dry_run != 'true' }}
-              run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add docs/versions.json docs/versioned_docs/ docs/versioned_sidebars/
-                  git commit -m "docs: snapshot version ${REF_NAME}" || echo "No changes to commit"
-                  git push
-              env:
-                  REF_NAME: ${{ github.ref_name }}
+            # TODO(versioned-docs): capture a per-release docs snapshot here in
+            # the future. It should be committed via the version-bump PR (so it
+            # goes through CLA and branch protection) rather than pushed to main
+            # from this workflow.

--- a/.gitignore
+++ b/.gitignore
@@ -12,13 +12,12 @@ examples/package-lock.json
 kubernetes-client-node-*.tgz
 **/*.swp
 .idea/
-docs/*
 .DS_Store
 
-# Docusaurus
-website/.docusaurus
-website/build
-website/node_modules
+# Docs: generated output is ignored via docs/.gitignore (build/, node_modules,
+# .docusaurus, docs/api-reference, docs/sdk, docs/models). Future versioned
+# snapshots (docs/versioned_docs, docs/versioned_sidebars, docs/versions.json)
+# are intentionally NOT ignored so they can be committed. See README.md.
 
 # Link-check scratch dir (created by docs CI to stage build under baseUrl)
 _linkcheck/

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Documentation is built with [Docusaurus](https://docusaurus.io/) and includes:
 
 - SDK Reference (KubeConfig, Watch, Informer, Exec, etc.)
 - Kubernetes API Reference (all API groups)
-- Version selector for historical releases
 - [Kubernetes API Reference](https://kubernetes.io/docs/reference/) — source-of-truth for all Kubernetes client libraries
 
 ## Preview docs locally
@@ -120,7 +119,7 @@ npm start          # opens http://localhost:3000 with hot-reload
 
 `npm start` automatically runs the `prestart` hook which generates the API
 reference, SDK docs, and model pages from source before launching the dev
-server.  Changes to hand-written docs (e.g. `docs/docs/examples/`) are
+server. Changes to hand-written docs (e.g. `docs/docs/examples/`) are
 reflected instantly; changes to the generated sources require restarting the
 server.
 
@@ -133,6 +132,12 @@ npm run serve      # preview the production build at http://localhost:3000
 ```
 
 There are several more JS and TS examples in the [examples](https://github.com/kubernetes-client/javascript/tree/main/examples) directory.
+
+> **TODO (versioned docs):** In the future the docs site will keep a snapshot of
+> the reference for each stable release, selectable via a version dropdown. This
+> isn't wired up yet — the site currently serves the latest (`main`) docs only.
+> When added, snapshots will be committed in the version-bump PR rather than
+> pushed from the release workflow.
 
 # Compatibility
 


### PR DESCRIPTION
Versioned per-release docs snapshots are not implemented yet.

Remove the non-functional snapshot steps from the release workflow and leave a clear TODO for the intended approach: capture the snapshot in the version-bump PR (so it goes through CLA and branch protection) instead of pushing to main from the release workflow.

Also drop the stale 'docs/*' and dead 'website/*' .gitignore rules from the website/ -> docs/ rename so the future versioned_docs snapshot can be committed when it lands.