### PR TITLE
disable copilot coauthor commit info following steering committee guidance

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,3 @@
+{
+    "includeCoAuthoredBy": false
+}


### PR DESCRIPTION
disable copilot coauthor commit info in alignment with steering committee guidelines on AI:
>Listing AI tooling as a co-author, co-signing commits using an AI tool, or using the assisted-by, co-developed or similar commit trailer is not allowed.

https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance

this change is intended so that the author of the PR, who must have signed the CLA, takes full commit credit for their work even when using copilot tools. this does not address PRs initiated by an agent, in which there isn't an author, as those will still fail CLA and are being discussed by steering committee for potential policy changes

this should unblock PRs where someone uses copilot to apply changes where it previously caused the CLA to trigger for the "copilot" committer

ref #3007