### PR TITLE
disable claude code co-author commit info

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+    "attribution": {
+        "commit": "",
+        "pr": "",
+        "sessionUrl": false
+    }
+}


### PR DESCRIPTION
PR #3010 disabled Copilot's co-author trailer via
.github/copilot/settings.json, but includeCoAuthoredBy is a Copilot-specific key. Contributors using Claude Code still get Co-Authored-By trailers.

Set attribution.commit and attribution.pr to empty strings, which suppresses both the commit trailer and the byline Claude Code adds to PR bodies. sessionUrl: false drops the claude.ai session link appended to commits and PRs created from web sessions.