### PR TITLE
ci: pin the Node 26 matrix entry to 26.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,10 @@ jobs:
             contents: read
         strategy:
             matrix:
-                node: ['26', '25', '24', '22']
+                # Pinned to 26.7: Node 26.8.0 rewrote fs.readFile
+                # (nodejs/node#65327) so that binding.open is no longer called
+                # from JS, which breaks mock-fs at require time
+                node: ['26.7', '25', '24', '22']
         name: Node ${{ matrix.node }} validation
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
mock-fs broke on node 26.8 https://github.com/tschaub/mock-fs/issues/447

proposing to pin tests to 26.7 while working on longer-term fix options

[SERVICEACCOUNT_ROOT](https://github.com/kubernetes-client/javascript/blob/f994a0f923f868b155b63d053d8308c4d681c01e/src/config.ts#L64) tests rely on mock-fs