### PR TITLE
Fix pretty option for pod log requests

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -64,7 +64,7 @@ export function AddOptionsToSearchParams(
     if (options?.limitBytes) {
         searchParams.set('limitBytes', options.limitBytes.toString());
     }
-    searchParams.set('pretty', options?.follow?.toString() || 'false');
+    searchParams.set('pretty', options?.pretty?.toString() || 'false');
     searchParams.set('previous', options?.previous?.toString() || 'false');
     if (options?.sinceSeconds) {
         searchParams.set('sinceSeconds', options?.sinceSeconds?.toString() || 'false');

--- a/src/log_test.ts
+++ b/src/log_test.ts
@@ -62,7 +62,7 @@ describe('Log', () => {
                 },
             });
             const options: LogOptions = {
-                follow: true,
+                follow: false,
                 limitBytes: 100,
                 pretty: true,
                 previous: true,
@@ -73,7 +73,7 @@ describe('Log', () => {
 
             pool.intercept({
                 method: 'GET',
-                path: '/api/v1/namespaces/default/pods/mypod/log?container=mycontainer&follow=true&limitBytes=100&pretty=true&previous=true&sinceSeconds=1&tailLines=1&timestamps=true',
+                path: '/api/v1/namespaces/default/pods/mypod/log?container=mycontainer&follow=false&limitBytes=100&pretty=true&previous=true&sinceSeconds=1&tailLines=1&timestamps=true',
             }).reply(200, 'log data');
 
             const controller = await log.log(namespace, podName, containerName, stream, options);

--- a/src/log_test.ts
+++ b/src/log_test.ts
@@ -188,7 +188,7 @@ describe('Log', () => {
         it('should add options to search params', () => {
             let searchParams = new URLSearchParams();
             let options: LogOptions = {
-                follow: true,
+                follow: false,
                 limitBytes: 100,
                 pretty: true,
                 previous: true,
@@ -197,7 +197,7 @@ describe('Log', () => {
                 timestamps: true,
             };
             AddOptionsToSearchParams(options, searchParams);
-            strictEqual(searchParams.get('follow'), 'true');
+            strictEqual(searchParams.get('follow'), 'false');
             strictEqual(searchParams.get('limitBytes'), '100');
             strictEqual(searchParams.get('pretty'), 'true');
             strictEqual(searchParams.get('previous'), 'true');


### PR DESCRIPTION
## Summary

- use `LogOptions.pretty` when setting the `pretty` query parameter for pod log requests
- add regression coverage where `follow` is false and `pretty` is true, ensuring the options are handled independently

This closes the pod logs parity gap identified in the client-go gap analysis.

## Testing

- `npm run build`
- `node --test --test-reporter=spec --import tsx src/log_test.ts`
- repository pre-commit test hooks